### PR TITLE
adapt for Centos security (selinux & firewall)

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -12,14 +12,7 @@ The system deployed is shown in the diagram below.
   * Bare Metal
   * Virtual Machine
   * EC2 instance (t3.large using ami-0affd4508a5d2481b in us-east-1)
-* User running the playbook must have the ability to `sudo`
-* SELinux is disabled
-
-  This can be achieved by running the following command:
-
-  ```bash
-  sudo setenforce 0;
-  ```
+* User running the playbook must have the ability to `sudo` any command
 
 ## Deploy
 

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -20,13 +20,30 @@
   notify:
     - reload nginx
 
-- name: Set httpd_can_network_connect flag on and keep it persistent across reboots
+- name: Check firewalld is installed
+  systemd:
+    name: firewalld
+  register: firewalld_svc
+
+- name: Allow required network flows
+  firewalld:
+    port: "{{ item.listen | default('80') }}/tcp"
+    permanent: yes
+    state: enabled
+    immediate: yes
+  with_items: "{{ nginx_vhosts }}"
+  when: firewalld_svc.status.UnitFileState is defined
+
+- name: Allow Nginx to run in SELinux context
   become: true
   seboolean:
-    name: httpd_can_network_connect
+    name: "{{ item }}"
     state: yes
     persistent: yes
   when: ansible_selinux.status == "enabled"
+  with_items:
+    - httpd_can_network_connect
+    - nis_enabled
 
 - name: Ensure nginx service is running as configured.
   service:


### PR DESCRIPTION
Allow for the playbook to create a system that's directly accessible and doesn't need SELinux to be disabled