### PR TITLE
OPSEXP-657:  Tag AWS reources

### DIFF
--- a/molecule/ec2/create.yml
+++ b/molecule/ec2/create.yml
@@ -67,7 +67,7 @@
         vpc_subnet_id: "{{ item.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
         instance_tags:
-          Creator: "{{ lookup('env', 'TRAVIS_BRANCH')_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}"
+          Creator: "{{ lookup('env', 'TRAVIS_BRANCH') }}_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}"
           Owner: "Operator Experience Team"
           Department: "Engineering"
           Purpose: "molecule_{{ lookup('env', 'TRAVIS_BRANCH') }}_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}_single"

--- a/molecule/ec2multi/create.yml
+++ b/molecule/ec2multi/create.yml
@@ -93,7 +93,7 @@
         vpc_subnet_id: "{{ item.0.vpc_subnet_id }}"
         group: "{{ security_group_name }}"
         instance_tags:
-          Creator: "{{ lookup('env', 'TRAVIS_BRANCH')_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}"
+          Creator: "{{ lookup('env', 'TRAVIS_BRANCH') }}_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}"
           Owner: "Operator Experience Team"
           Department: "Engineering"
           Purpose: "molecule_{{ lookup('env', 'TRAVIS_BRANCH') }}_{{ lookup('env', 'TRAVIS_BUILD_NUMBER') }}_multi"


### PR DESCRIPTION
I made use of TRAVIS_BRANCH and TRAVIS_BUILD_NUMBER to tag the AWS resources. I did that in order to not introduce any more variables in our scripts