### PR TITLE
OPSEXP-667: Fix static user & group IDs

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -16,31 +16,17 @@
   poll: 0
   loop: "{{ utils }}"
 
-- name: "Check existence of {{ group_name }} group"
-  shell: "cat /etc/group | grep {{ group_name }}"
-  register: group_presence
-  failed_when: false
-  changed_when: group_presence.rc != 0
-
 - name: "Create {{ group_name }} group"
   group:
       name: "{{ group_name }}"
-      gid: "{{ group_id }}"
-  when: group_presence.rc != 0
-
-- name: "Check existence of {{ username }} user"
-  command: "id -u {{ username }}"
-  register: user_presence
-  failed_when: false
-  changed_when: user_presence.rc != 0
+      system: yes
 
 - name: "Create {{ username }} user"
   user:
     name: "{{ username }}"
     comment: "{{ username }} user"
-    uid: "{{ user_id }}"
+    system: yes
     group: "{{ group_name }}"
-  when: user_presence.rc != 0
 
 - name: "Check for binaries folder"
   stat:

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -7,9 +7,7 @@ nexus_user: "{{ lookup('env', 'NEXUS_USERNAME') }}"
 nexus_password: "{{ lookup('env', 'NEXUS_PASSWORD') }}"
 
 group_name: Alfresco
-group_id: 1001
 username: alfresco
-user_id: 33031
 
 maven_repository:
    org: "https://repo.maven.apache.org/maven2/org"


### PR DESCRIPTION
Removed static UID and GID to avoid conflicts
Removed tasks that check for the existence of user and group, because the ansible modules that create system users and groups are idempotent