### PR TITLE
OPSEXP-695: Don't move ACS license folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
         - molecule verify
         - molecule destroy
     - stage: Verification
-      name: Localhost integration checks (ACS 6.2.2)
+      name: Localhost integration checks (ACS 6.2.2 on CentOS 7)
       before_install:
         - openssl aes-256-cbc -K $encrypted_6c8b9ee48a27_key -iv $encrypted_6c8b9ee48a27_iv -in alfresco-ansible.pem.enc -out /tmp/dbp-ansible -d
         - eval "$(ssh-agent -s)"
@@ -141,7 +141,7 @@ jobs:
         - cd dtas; pytest --verbose  --configuration ../test-config-acs6-stack.json tests/ -s
         - if [[ "$TRAVIS_COMMIT_MESSAGE" != *"[keep env]"* ]]; then aws ec2 terminate-instances --instance-ids $INSTANCE_ID; fi
     - stage: Verification
-      name: CentOS8 integration checks
+      name: Localhost integration checks (ACS 7.0.0 on CentOS 8)
       before_install:
         - openssl aes-256-cbc -K $encrypted_6c8b9ee48a27_key -iv $encrypted_6c8b9ee48a27_iv -in alfresco-ansible.pem.enc -out /tmp/dbp-ansible -d
         - eval "$(ssh-agent -s)"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :ansible_local do |ansible|
     ansible.playbook = "playbooks/acs.yml"
     ansible.inventory_path = "inventory_local.yml"
-    ansible.install_mode = "pip"
-    ansible.version = "2.9.15"
     ansible.limit = "all"
     ansible.become = true
     ansible.extra_vars = {

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -35,7 +35,6 @@
      - "{{ content_folder }}/alf_data"
      - "{{ content_folder }}/alfresco-mmt"
      - "{{ content_folder }}/webapps/alfresco"
-     - "{{ content_folder }}/licenses/"
      - "{{ content_folder }}/web-server/lib"
      - "{{ settings_folder }}/classpath/alfresco/extension/transform/pipelines"
      - "{{ settings_folder }}/classpath/alfresco/extension/transform/renditions"
@@ -44,7 +43,6 @@
      - "{{ content_data_folder }}/keystore"
      - "{{ tomcat_config_dir }}/lib"
      - "{{ tomcat_config_dir }}/conf/Catalina/localhost"
-     - "{{ logs_folder }}/licenses/"
 
 - name: Check if Alfresco version {{ acs.version }} is installed
   stat:
@@ -192,27 +190,7 @@
     state: absent
   when: archive_exists.stat.exists
 
-- name: Move licenses folder
-  block:
-    - name: Check if source license folder exists
-      stat:
-        path: "{{ content_folder }}/licenses"
-      register: licences
-    - name: Copy licenses folder to {{ settings_folder }}
-      copy:
-        remote_src: true
-        src: "{{ content_folder }}/licenses"
-        dest: "{{ settings_folder }}"
-        owner: "{{ username }}"
-        group: "{{ group_name }}"
-        mode: 'u=rwx,g=rwx,o=rx'
-      when: licences.stat.exists
-    - name: Remove licenses folder
-      file:
-        path: "{{ content_folder }}/licenses"
-        state: absent
-
-- name: Copy license files if existent in inventory
+- name: Copy user provided license file
   block:
     - name: copy local files to remote
       copy:

--- a/roles/transformers/vars/main.yml
+++ b/roles/transformers/vars/main.yml
@@ -2,15 +2,12 @@
 # vars file for transformers
 temp_dir: /tmp/ansible_transformation
 
-libreoffice_home: "/opt/libreoffice{{ libreoffice[0:3] }}/"
 imagemagick_home: "/usr/lib64/ImageMagick-{{ imagemagick_version[0:6] }}"
-
-
 imagemagick_rpm: "https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/{{ imagemagick_version }}/imagemagick-distribution-{{ imagemagick_version }}-linux.rpm"
 imagemagick_lib_rpm: "https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/imagemagick/imagemagick-distribution/{{ imagemagick_version }}/imagemagick-distribution-{{ imagemagick_version }}-libs-linux.rpm"
 imagemagick_dep_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-imagemagick_license: "https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/ImageMagick-license.txt"
+
+libreoffice_home: "/opt/libreoffice{{ libreoffice[0:3] }}/"
 libreoffice_rpm: "https://nexus.alfresco.com/nexus/service/local/repositories/thirdparty/content/org/libreoffice/libreoffice-dist/{{ libreoffice }}/libreoffice-dist-{{ libreoffice }}-linux.gz"
-libreoffice_license_file: "https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/libreoffice.txt"
+
 alfresco_pdf_renderer_lib_rpm: "https://nexus.alfresco.com/nexus/service/local/repositories/releases/content/org/alfresco/alfresco-pdf-renderer/{{ pdf_renderer }}/alfresco-pdf-renderer-{{ pdf_renderer }}-linux.tgz"
-pdfium_license_file: "https://github.com/Alfresco/acs-community-packaging/blob/master/distribution/src/main/resources/licenses/3rd-party/pdfium.txt"


### PR DESCRIPTION
- Don't move the ACS licenses folder to the settings area
- Remove unused license variables from transformers role
- Change localhost deployment stage names
- Fix vagrantfile again (just install latest version of Ansible)