### PR TITLE
OPSEXP-782: Fix for external DB support

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -116,7 +116,6 @@
   block:
     - name: Copy db_connector_repo
       copy:
-        remote_src: true
         src: "{{ inventory_dir }}/configuration_files/db_connector_repo/"
         dest: "{{ tomcat_config_dir }}/lib/"
         owner: "{{ username }}"

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -79,7 +79,6 @@
       when: sync_db_url == ""
     - name: Copy db_connector to {{ sync_home }}/service-sync/connectors folder
       copy:
-        remote_src: true
         src: "{{ inventory_dir }}/configuration_files/db_connector_sync/"
         dest: "{{ sync_home }}/service-sync/connectors/"
         owner: "{{ username }}"


### PR DESCRIPTION
jdbc drivers are copied from the controller host so source isn't remote