### PR TITLE
OPSEXP-818:  revisit the way services are handled

### DIFF
--- a/roles/activemq/handlers/main.yml
+++ b/roles/activemq/handlers/main.yml
@@ -1,13 +1,31 @@
 ---
+# handlers file for activemq
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: enable-activemq
+  service:
+    name: activemq
+    enabled: true
+    daemon_reload: true
+  when: services_state.ansible_facts.services['activemq.service'].status != 'enabled'
+
+- name: start-activemq
+  service:
+    name: activemq
+    state: started
+    daemon_reload: true
+  when: services_state.ansible_facts.services['activemq.service'].state != 'running'
+
 - name: restart-activemq
   service:
     name: activemq
     state: restarted
     daemon_reload: true
+  when: services_state.ansible_facts.services['activemq.service'].state == 'running'
 
-- name: enable-start-activemq
+- name: stop-activemq
   service:
     name: activemq
-    state: started
-    enabled: true
-    daemon_reload: true
+    state: stopped

--- a/roles/activemq/handlers/main.yml
+++ b/roles/activemq/handlers/main.yml
@@ -1,6 +1,13 @@
 ---
-- name: activemq-restart
-  systemd:
+- name: restart-activemq
+  service:
     name: activemq
     state: restarted
+    daemon_reload: true
+
+- name: enable-start-activemq
+  service:
+    name: activemq
+    state: started
+    enabled: true
     daemon_reload: true

--- a/roles/activemq/molecule/default/molecule.yml
+++ b/roles/activemq/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - side_effect
     - verify
     - cleanup

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -139,7 +139,7 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
-  notify: 
+  notify:
     - get-services
     - enable-activemq
     - start-activemq

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -127,7 +127,7 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,go=rx'
-  notify: activemq-restart
+  notify: restart-activemq
 
 - name: Add activemq.service
   template:
@@ -136,10 +136,4 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
-  notify: activemq-restart
-
-- name: Ensure activemq service is started and enabled on boot
-  systemd:
-    name: activemq.service
-    state: started
-    enabled: true
+  notify: enable-start-activemq

--- a/roles/activemq/tasks/main.yml
+++ b/roles/activemq/tasks/main.yml
@@ -10,7 +10,7 @@
   become_user: root
   get_url:
     url: "{{ dependencies_url.activemq }}"
-    dest: "/opt/apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz"
+    dest: "{{ download_location }}/apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz"
     mode: 'u=rwx,g=rwx,o=rx'
     owner: "{{ username }}"
     group: "{{ group_name }}"
@@ -33,11 +33,12 @@
 - name: Extract apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz into /opt
   become: true
   unarchive:
-    src: "/opt/apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz"
+    src: "{{ download_location }}/apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz"
     dest: "/opt"
     remote_src: true
     owner: "{{ username }}"
     group: "{{ group_name }}"
+    creates: "/opt/apache-activemq-{{ dependencies_version.activemq }}/bin"
   when: job_result is succeeded
 
 - name: Move configuration files
@@ -127,7 +128,9 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,go=rx'
-  notify: restart-activemq
+  notify:
+    - get-services
+    - restart-activemq
 
 - name: Add activemq.service
   template:
@@ -136,4 +139,8 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
-  notify: enable-start-activemq
+  notify: 
+    - get-services
+    - enable-activemq
+    - start-activemq
+    - restart-activemq

--- a/roles/adw/handlers/main.yml
+++ b/roles/adw/handlers/main.yml
@@ -1,13 +1,43 @@
 ---
 # handlers file for adw
-- name: validate nginx configuration
-  command: nginx -t -c /etc/nginx/nginx.conf
-  changed_when: false
-- name: reload nginx
-  service: name=nginx state=reloaded
+# - name: validate nginx configuration
+#   command: nginx -t -c /etc/nginx/nginx.conf
+#   changed_when: false
+
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: enable-nginx
+  service:
+    name: nginx
+    enabled: true
+    daemon_reload: true
   become: true
   become_user: root
-- name: restart nginx
-  service: name=nginx state=restarted
+  when: services_state.ansible_facts.services['nginx.service'].status != 'enabled'
+
+- name: start-nginx
+  service: 
+    name: nginx 
+    state: started
+    daemon_reload: true
+  become: true
+  become_user: root
+  when: services_state.ansible_facts.services['nginx.service'].state != 'running'
+
+- name: restart-nginx
+  service: 
+    name: nginx 
+    state: restarted
+    daemon_reload: true
+  become: true
+  become_user: root
+  when: services_state.ansible_facts.services['nginx.service'].state == 'running'
+
+- name: reload-nginx
+  service: 
+    name: nginx 
+    state: reloaded
   become: true
   become_user: root

--- a/roles/adw/handlers/main.yml
+++ b/roles/adw/handlers/main.yml
@@ -1,9 +1,5 @@
 ---
 # handlers file for adw
-# - name: validate nginx configuration
-#   command: nginx -t -c /etc/nginx/nginx.conf
-#   changed_when: false
-
 - name: get-services
   service_facts:
   register: services_state

--- a/roles/adw/tasks/nginx.yml
+++ b/roles/adw/tasks/nginx.yml
@@ -41,10 +41,10 @@
     group: root
     mode: 'u=rw,g=r,o=r'
     notify:
-    - get-services
-    - enable-nginx
-    - start-nginx
-    - restart-nginx
+      - get-services
+      - enable-nginx
+      - start-nginx
+      - restart-nginx
 
 - name: Set nis_enabled flag on and keep it persistent across reboots
   become: true

--- a/roles/adw/tasks/nginx.yml
+++ b/roles/adw/tasks/nginx.yml
@@ -32,12 +32,12 @@
     path: "{{ nginx_vhost_path }}/vhosts.conf"
     state: absent
 
-- name: Ensure nginx service is running as configured.
-  service:
-    name: nginx
-    state: started
-    enabled: true
-  notify: restart nginx
+# - name: Ensure nginx service is running as configured.
+#   service:
+#     name: nginx
+#     state: started
+#     enabled: true
+#   notify: restart-nginx
 
 - name: Add managed vhost config files.
   template:
@@ -47,4 +47,8 @@
     owner: root
     group: root
     mode: 'u=rw,g=r,o=r'
-  notify: reload nginx
+  notify:
+    - get-services
+    - enable-nginx
+    - start-nginx
+    - restart-nginx

--- a/roles/adw/tasks/nginx.yml
+++ b/roles/adw/tasks/nginx.yml
@@ -40,11 +40,11 @@
     owner: root
     group: root
     mode: 'u=rw,g=r,o=r'
-    notify:
-      - get-services
-      - enable-nginx
-      - start-nginx
-      - restart-nginx
+  notify:
+    - get-services
+    - enable-nginx
+    - start-nginx
+    - restart-nginx
 
 - name: Set nis_enabled flag on and keep it persistent across reboots
   become: true

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,7 +1,9 @@
 ---
 # handlers file for nginx
-- name: restart nginx
-  service: name=nginx state=restarted
+- name: restart-nginx
+  service: 
+    name: nginx
+    state: restarted
   become: true
   become_user: root
 
@@ -9,7 +11,9 @@
   command: nginx -t -c /etc/nginx/nginx.conf
   changed_when: false
 
-- name: reload nginx
-  service: name=nginx state=reloaded
+- name: reload-nginx
+  service: 
+    name: nginx
+    state: reloaded
   become: true
   become_user: root

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -49,8 +49,4 @@
     name: nginx
     state: "{{ nginx_service_state }}"
     enabled: "{{ nginx_service_enabled }}"
-<<<<<<< HEAD
   notify: reload-nginx
-=======
-  notify: reload nginx
->>>>>>> master

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -34,8 +34,7 @@
     owner: root
     group: "{{ root_group }}"
     mode: 'u=rw,g=r,o=r'
-  notify:
-    - reload nginx
+  notify: reload-nginx
 
 - name: Set httpd_can_network_connect flag on and keep it persistent across reboots
   become: true
@@ -53,4 +52,4 @@
     name: nginx
     state: "{{ nginx_service_state }}"
     enabled: "{{ nginx_service_enabled }}"
-  notify: reload nginx
+  notify: reload-nginx

--- a/roles/nginx/tasks/vhosts.yml
+++ b/roles/nginx/tasks/vhosts.yml
@@ -4,13 +4,13 @@
     path: "{{ nginx_default_vhost_path }}"
     state: absent
   when: nginx_remove_default_vhost | bool
-  notify: reload nginx
+  notify: reload-nginx
 
 - name: Ensure nginx_vhost_path exists.
   file:
     path: "{{ nginx_vhost_path }}"
     state: directory
-  notify: reload nginx
+  notify: reload-nginx
 
 - name: Add ssl key
   template:
@@ -40,10 +40,10 @@
     mode: 0644
   when: item.state|default('present') != 'absent'
   with_items: "{{ nginx_vhosts }}"
-  notify: reload nginx
+  notify: reload-nginx
 
 - name: Remove legacy vhosts.conf file.
   file:
     path: "{{ nginx_vhost_path }}/vhosts.conf"
     state: absent
-  notify: reload nginx
+  notify: reload-nginx

--- a/roles/postgres/handlers/main.yml
+++ b/roles/postgres/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart postgresql
-  systemd:
+  service:
     name: "{{ postgresql_service }}"
     state: restarted

--- a/roles/repository/handlers/main.yml
+++ b/roles/repository/handlers/main.yml
@@ -1,25 +1,25 @@
 ---
 # handlers file for repository
-- name: alfresco-content-restart
-  systemd:
+- name: restart-alfresco-content
+  service:
     name: "alfresco-content"
     state: restarted
     daemon_reload: true
 
-- name: alfresco-content-reload
-  systemd:
+- name: reload-alfresco-content
+  service:
     name: "alfresco-content"
     state: reloaded
     daemon_reload: true
 
-- name: alfresco-content-stop
-  systemd:
+- name: stop-alfresco-content
+  service:
     name: "alfresco-content"
     state: stopped
     daemon_reload: true
 
-- name: alfresco-content-start
-  systemd:
+- name: start-alfresco-content
+  service:
     name: "alfresco-content"
     state: started
     daemon_reload: true

--- a/roles/repository/handlers/main.yml
+++ b/roles/repository/handlers/main.yml
@@ -13,7 +13,7 @@
 - name: enable-alfresco-content
   service:
     name: "alfresco-content"
-    state: enabled
+    enabled: true
     daemon_reload: true
   when: not go_signal.failed and services_state.ansible_facts.services['alfresco-content.service'].status != 'enabled'
 

--- a/roles/repository/handlers/main.yml
+++ b/roles/repository/handlers/main.yml
@@ -9,6 +9,14 @@
     host: "{{ db_host }}"
     port: "{{ repo_db_port }}"
   register: go_signal
+  when: repo_db_url == ""
+
+- name: set-go-signal
+  set_fact:
+    go_signal: {
+      'failed': false
+    }
+  when: repo_db_url != ""
 
 - name: enable-alfresco-content
   service:

--- a/roles/repository/handlers/main.yml
+++ b/roles/repository/handlers/main.yml
@@ -1,10 +1,35 @@
 ---
 # handlers file for repository
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: wait-for-db
+  wait_for:
+    host: "{{ db_host }}"
+    port: "{{ repo_db_port }}"
+  register: go_signal
+
+- name: enable-alfresco-content
+  service:
+    name: "alfresco-content"
+    state: enabled
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-content.service'].status != 'enabled'
+
+- name: start-alfresco-content
+  service:
+    name: "alfresco-content"
+    state: started
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-content.service'].state != 'running'
+
 - name: restart-alfresco-content
   service:
     name: "alfresco-content"
     state: restarted
     daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-content.service'].state == 'running'
 
 - name: reload-alfresco-content
   service:
@@ -16,10 +41,3 @@
   service:
     name: "alfresco-content"
     state: stopped
-    daemon_reload: true
-
-- name: start-alfresco-content
-  service:
-    name: "alfresco-content"
-    state: started
-    daemon_reload: true

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -441,13 +441,13 @@
     marker_end: "### End - Custom user properties"
     insertafter: EOF
     block: "{{ lookup('file', role_path + '/../../configuration_files/alfresco-global.properties') }}"
-  notify: alfresco-content-restart
+  notify: restart-alfresco-content
 
 - name: Notify alfresco content service
   wait_for:
     host: "{{ db_host }}"
     port: "{{ repo_db_port }}"
-  notify: alfresco-content-start
+  notify: start-alfresco-content
   when: repo_db_url == ""
 
 - name: Alfresco content service for external db

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -444,18 +444,6 @@
   notify:
     - get-services
     - wait-for-db
+    - set-go-signal
     - start-alfresco-content
     - restart-alfresco-content
-
-# - name: Notify alfresco content service
-#   wait_for:
-#     host: "{{ db_host }}"
-#     port: "{{ repo_db_port }}"
-#   notify: start-alfresco-content
-#   when: repo_db_url == ""
-
-# - name: Alfresco content service for external db
-#   service:
-#     name: alfresco-content 
-#     state: restarted
-#   when: repo_db_url != ""

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -441,17 +441,21 @@
     marker_end: "### End - Custom user properties"
     insertafter: EOF
     block: "{{ lookup('file', role_path + '/../../configuration_files/alfresco-global.properties') }}"
-  notify: restart-alfresco-content
+  notify:
+    - get-services
+    - wait-for-db
+    - start-alfresco-content
+    - restart-alfresco-content
 
-- name: Notify alfresco content service
-  wait_for:
-    host: "{{ db_host }}"
-    port: "{{ repo_db_port }}"
-  notify: start-alfresco-content
-  when: repo_db_url == ""
+# - name: Notify alfresco content service
+#   wait_for:
+#     host: "{{ db_host }}"
+#     port: "{{ repo_db_port }}"
+#   notify: start-alfresco-content
+#   when: repo_db_url == ""
 
-- name: Alfresco content service for external db
-  service:
-    name: alfresco-content 
-    state: restarted
-  when: repo_db_url != ""
+# - name: Alfresco content service for external db
+#   service:
+#     name: alfresco-content 
+#     state: restarted
+#   when: repo_db_url != ""

--- a/roles/search/handlers/main.yml
+++ b/roles/search/handlers/main.yml
@@ -1,7 +1,31 @@
 ---
 # handlers file for search-services
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: enable-search
+  service:
+    name: alfresco-search
+    enabled: true
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-search.service'].status != 'enabled'
+
+- name: start-search
+  service:
+    name: alfresco-search
+    state: started
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-search.service'].state != 'running'
+
 - name: restart-search
   service:
     name: alfresco-search
     state: restarted
     daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-search.service'].state == 'running'
+
+- name: stop-search
+  service:
+    name: alfresco-search
+    state: stopped

--- a/roles/search/molecule/default/molecule.yml
+++ b/roles/search/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - side_effect
     - verify
 dependency:

--- a/roles/search/tasks/main.yml
+++ b/roles/search/tasks/main.yml
@@ -1,13 +1,5 @@
 ---
 # tasks file for search-services
-- name: Check search is installed
-  command: "{{ binaries_dir }}/solr/bin/solr.version"
-  register: search_install_check
-  environment:
-      JAVA_HOME: "{{ java_home }}"
-  failed_when: false
-  changed_when: search_install_check.rc != 0
-
 - name: Ensure a list of packages installed
   become: true
   become_user: root
@@ -30,11 +22,6 @@
     - "{{ config_dir }}"
     - "{{ data_dir }}"
 
-- name: "Check if alfresco-search-services-{{ search.version }}.zip exists"
-  stat:
-    path: "{{ download_location }}/alfresco-search-services-{{ search.version }}.zip"
-  register: search_archive
-
 - name: "Download alfresco-search-services-{{ search.version }}.zip"
   get_url:
     url: "{{ downloads.search_zip_url }}"
@@ -46,7 +33,6 @@
     timeout: 570
   register: download_result
   until: download_result is succeeded
-  when: not search_archive.stat.exists and search_install_check.rc != 0
 
 - name: Extract alfresco-search-services-{{ search.version }}.zip into {{ binaries_dir }}
   become: true
@@ -120,6 +106,9 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
+  notify:
+    - get-services
+    - restart-search
 
 - name: Add "{{ config_dir }}/solr.in.sh"
   become: true
@@ -129,6 +118,9 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
+  notify:
+    - get-services
+    - restart-search
 
 - name: Check Solr running
   shell: "{{ binaries_dir }}/solr/bin/solr status"
@@ -146,11 +138,9 @@
       owner: "{{ username }}"
       group: "{{ group_name }}"
       mode: 'u=rwx,g=rwx'
-  notify: restart-search
+  notify: 
+    - get-services
+    - enable-search
+    - start-search
+    - restart-search
   when: search_started.failed or '"No Solr nodes are running." in search_started.stdout'
-
-- name: Ensure Alfresco Search service is started and enabled on boot
-  systemd:
-    name: alfresco-search.service
-    state: started
-    enabled: true

--- a/roles/sfs/handlers/main.yml
+++ b/roles/sfs/handlers/main.yml
@@ -4,16 +4,19 @@
   service:
     name: alfresco-shared-fs
     state: restarted
-    daemon_reload: true
 
 - name: start-sfs
   service:
     name: alfresco-shared-fs
     state: started
-    daemon_reload: true
+
+- name: start-enable-sfs
+  service:
+    name: alfresco-shared-fs
+    state: started
+    enabled: true
 
 - name: stop-sfs
   service:
     name: alfresco-shared-fs
     state: stopped
-    daemon_reload: true

--- a/roles/sfs/handlers/main.yml
+++ b/roles/sfs/handlers/main.yml
@@ -1,20 +1,29 @@
 ---
 # handlers file for sfs
-- name: restart-sfs
-  service:
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: enable-sfs
+  service: 
     name: alfresco-shared-fs
-    state: restarted
+    enabled: true
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-shared-fs.service'].status != 'enabled'
 
 - name: start-sfs
   service:
     name: alfresco-shared-fs
     state: started
-
-- name: start-enable-sfs
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-shared-fs.service'].state != 'running'
+    
+- name: restart-sfs
   service:
     name: alfresco-shared-fs
-    state: started
-    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-shared-fs.service'].state == 'running'
 
 - name: stop-sfs
   service:

--- a/roles/sfs/molecule/default/molecule.yml
+++ b/roles/sfs/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - side_effect
     - verify
     - cleanup

--- a/roles/sfs/tasks/main.yml
+++ b/roles/sfs/tasks/main.yml
@@ -43,7 +43,10 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-sfs
+  notify:
+    - get-services
+    - restart-sfs
+
 
 - name: Add paths to setenv file
   become: true
@@ -81,4 +84,8 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: start-enable-sfs
+  notify:
+    - get-services
+    - enable-sfs
+    - start-sfs
+    - restart-sfs

--- a/roles/sfs/tasks/main.yml
+++ b/roles/sfs/tasks/main.yml
@@ -46,29 +46,16 @@
   notify: restart-sfs
 
 - name: Add paths to setenv file
-  block:
-    - name: Check for ATS_HOME in "{{ config_folder }}/setenv.sh"
-      shell: cat {{ config_folder }}/setenv.sh | grep ATS_HOME
-      register: test_ats_home
-      failed_when: false
-      changed_when: test_ats_home.rc != 0
-    - name: Check for ACTIVEMQ_HOST in "{{ config_folder }}/setenv.sh"
-      shell: cat {{ config_folder }}/setenv.sh | grep ACTIVEMQ_HOST
-      register: test_activemq_home
-      failed_when: false
-      changed_when: test_activemq_home.rc != 0
-    - name: Add paths to setenv file
-      become: true
-      become_user: "{{ username }}"
-      blockinfile:
-        path: "{{ config_folder }}/setenv.sh"
-        marker: "# {mark} SFS ENV VARS"
-        block: |
-          export ATS_HOME={{ binaries_folder }}/transform-service
-          export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
-          export ATS_SHARED_FS_HOST={{ sfs_host }}
-        insertafter: EOF
-      when: test_ats_home.rc != 0 and test_activemq_home.rc != 0
+  become: true
+  become_user: "{{ username }}"
+  blockinfile:
+    path: "{{ config_folder }}/setenv.sh"
+    marker: "# {mark} ATS COMMON ENV VARS"
+    block: |
+      export ATS_HOME={{ binaries_folder }}/transform-service
+      export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
+      export ATS_SHARED_FS_HOST={{ sfs_host }}
+    insertafter: EOF
 
 - name: Create log file with correct permissions
   become: true
@@ -77,6 +64,12 @@
     path: "{{ logs_folder }}/ats-shared-fs.log"
     state: touch
     mode: u=rwx,g=rw,o-rwx
+  changed_when: false
+
+- name: clean all
+  command: yum clean all
+  args:
+    warn: false
   changed_when: false
 
 - name: Add alfresco-shared-fs service
@@ -88,16 +81,4 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-sfs
-
-- name: clean all
-  command: yum clean all
-  args:
-    warn: false
-  changed_when: false
-
-- name: Enable and start sfs service
-  systemd:
-    name: alfresco-shared-fs.service
-    enabled: true
-  notify: start-sfs
+  notify: start-enable-sfs

--- a/roles/sync/handlers/main.yml
+++ b/roles/sync/handlers/main.yml
@@ -1,19 +1,37 @@
 ---
 # handlers file for trouter
-- name: restart-sync
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: wait-for-repo
+  wait_for:
+    host: "{{ repo_host }}"
+    port: 8080
+  register: go_signal
+
+- name: enable-sync
   service:
     name: alfresco-sync
-    state: restarted
+    enabled: true
     daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-sync.service'].status != 'enabled'
 
 - name: start-sync
   service:
     name: alfresco-sync
     state: started
     daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-sync.service'].state != 'running'
+
+- name: restart-sync
+  service:
+    name: alfresco-sync
+    state: restarted
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-sync.service'].state == 'running'
 
 - name: stop-sync
   service:
     name: alfresco-sync
     state: stopped
-    daemon_reload: true

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -163,6 +163,7 @@
     force: no
   notify:
     - get-services
+    - wait-for-repo
     - restart-sync
 
 - name: Add alfresco-sync.service service
@@ -176,6 +177,7 @@
     force: yes
   notify:
   - get-services
+  - wait-for-repo
   - enable-sync
   - start-sync 
   - restart-sync

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -113,7 +113,10 @@
         group: "{{ group_name }}"
         mode: 'u=rwx,g=rwx'
         force: yes
-      notify: restart-sync
+      notify:
+        - get-services
+        - wait-for-repo 
+        - restart-sync
 
 - name: Check for SYNC_HOME in "{{ config_folder }}/setenv.sh"
   shell: cat {{ config_folder }}/setenv.sh | grep SYNC_HOME
@@ -142,6 +145,12 @@
     mode: u=rwx,g=rw,o-rwx
   changed_when: false
 
+- name: clean all
+  command: yum clean all
+  args:
+    warn: false
+  changed_when: false
+
 - name: Add sync service startup script
   become: true
   become_user: "{{ username }}"
@@ -152,6 +161,9 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx'
     force: no
+  notify:
+    - get-services
+    - restart-sync
 
 - name: Add alfresco-sync.service service
   become: true
@@ -162,28 +174,8 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx'
     force: yes
-  notify: restart-sync
-  when: not ansible_facts.services['alfresco-sync.service'] is defined
-
-- name: clean all
-  command: yum clean all
-  args:
-    warn: false
-  changed_when: false
-
-- name: Remove sync service archive
-  file:
-    path: "{{ binaries_folder }}/sync-dist-6.x-{{ sync.version }}.zip"
-    state: absent
-
-- name: Enable Sync service
-  systemd:
-    name: alfresco-sync.service
-    state: stopped
-    enabled: true
-
-- name: Notify sync service service to start
-  wait_for:
-    host: "{{ repo_host }}"
-    port: 8080
-  notify: start-sync
+  notify:
+  - get-services
+  - enable-sync
+  - start-sync 
+  - restart-sync

--- a/roles/tomcat/handlers/main.yml
+++ b/roles/tomcat/handlers/main.yml
@@ -1,12 +1,19 @@
 ---
-- name: alfresco-content-start
-  systemd:
+- name: start-alfresco-content
+  service:
     name: "alfresco-content"
     state: started
     daemon_reload: true
 
-- name: alfresco-content-stop
-  systemd:
+- name: stop-alfresco-content
+  service:
     name: "alfresco-content"
     state: stopped
+    daemon_reload: true
+
+- name: enable-alfresco-content
+  service:
+    name: "alfresco-content"
+    state: stopped
+    enabled: true
     daemon_reload: true

--- a/roles/tomcat/handlers/main.yml
+++ b/roles/tomcat/handlers/main.yml
@@ -1,19 +1,24 @@
 ---
+# handlers file for tomcat (alfresco-content)
+- name: get-services
+  service_facts:
+  register: services_state
+
+- name: enable-alfresco-content
+  service:
+    name: "alfresco-content"
+    state: enabled
+    daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-content.service'].status != 'enabled'
+
 - name: start-alfresco-content
   service:
     name: "alfresco-content"
     state: started
     daemon_reload: true
+  when: services_state.ansible_facts.services['alfresco-content.service'].state != 'running'
 
 - name: stop-alfresco-content
   service:
     name: "alfresco-content"
     state: stopped
-    daemon_reload: true
-
-- name: enable-alfresco-content
-  service:
-    name: "alfresco-content"
-    state: stopped
-    enabled: true
-    daemon_reload: true

--- a/roles/tomcat/handlers/main.yml
+++ b/roles/tomcat/handlers/main.yml
@@ -7,7 +7,7 @@
 - name: enable-alfresco-content
   service:
     name: "alfresco-content"
-    state: enabled
+    enabled: true
     daemon_reload: true
   when: services_state.ansible_facts.services['alfresco-content.service'].status != 'enabled'
 

--- a/roles/tomcat/molecule/default/converge.yml
+++ b/roles/tomcat/molecule/default/converge.yml
@@ -7,7 +7,7 @@
         name: "tomcat"
 
     - name: Ensure tomcat service is started and enabled on boot
-      systemd:
+      service:
         name: alfresco-content.service
         state: started
       changed_when: false

--- a/roles/tomcat/molecule/default/molecule.yml
+++ b/roles/tomcat/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - side_effect
     - verify
     - cleanup

--- a/roles/tomcat/tasks/main.yml
+++ b/roles/tomcat/tasks/main.yml
@@ -183,11 +183,4 @@
       owner: "{{ username }}"
       group: "{{ group_name }}"
   when: install_check.rc != 0 or dependencies_version.tomcat not in install_check.stderr
-
-- name: Ensure tomcat service is enabled on boot
-  systemd:
-    name: alfresco-content.service
-    state: stopped
-    enabled: true
-    daemon_reload: yes
-  changed_when: false
+  notify: enable-alfresco-content

--- a/roles/tomcat/tasks/main.yml
+++ b/roles/tomcat/tasks/main.yml
@@ -183,4 +183,6 @@
       owner: "{{ username }}"
       group: "{{ group_name }}"
   when: install_check.rc != 0 or dependencies_version.tomcat not in install_check.stderr
-  notify: enable-alfresco-content
+  notify:
+    - get-services
+    - enable-alfresco-content

--- a/roles/transformers/handlers/main.yml
+++ b/roles/transformers/handlers/main.yml
@@ -5,16 +5,24 @@
   service:
     name: alfresco-tengine-aio
     state: restarted
-    daemon_reload: true
 
 - name: start-aio
   service:
     name: alfresco-tengine-aio
     state: started
-    daemon_reload: true
+
+- name: enable-start-aio
+  service:
+    name: alfresco-tengine-aio
+    state: start
+    enabled: true
 
 - name: stop-aio
   service:
     name: alfresco-tengine-aio
     state: stopped
-    daemon_reload: true
+
+- name: reload-aio
+  service:
+    name: alfresco-tengine-aio
+    state: reloaded

--- a/roles/transformers/handlers/main.yml
+++ b/roles/transformers/handlers/main.yml
@@ -1,28 +1,37 @@
 ---
 # handlers file for roles/transformers
+- name: get-services
+  service_facts:
+  register: services_state
 
-- name: restart-aio
+- name: wait-for-activemq
+  wait_for:
+    host: "{{ activemq_host }}"
+    port: 61616
+  register: go_signal
+
+- name: enable-aio
   service:
     name: alfresco-tengine-aio
-    state: restarted
+    enabled: true
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-tengine-aio.service'].status != 'enabled'
 
 - name: start-aio
   service:
     name: alfresco-tengine-aio
     state: started
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-tengine-aio.service'].state != 'running'
 
-- name: enable-start-aio
+- name: restart-aio
   service:
     name: alfresco-tengine-aio
-    state: start
-    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-tengine-aio.service'].state == 'running'
 
 - name: stop-aio
   service:
     name: alfresco-tengine-aio
     state: stopped
-
-- name: reload-aio
-  service:
-    name: alfresco-tengine-aio
-    state: reloaded

--- a/roles/transformers/molecule/default/converge.yml
+++ b/roles/transformers/molecule/default/converge.yml
@@ -5,6 +5,7 @@
     - name: "Include activemq"
       include_role:
         name: "activemq"
+    - meta: flush_handlers
     - name: "Include transformers"
       include_role:
         name: "transformers"

--- a/roles/transformers/molecule/default/molecule.yml
+++ b/roles/transformers/molecule/default/molecule.yml
@@ -36,6 +36,7 @@ platforms:
       - 8099/tcp
       - 8983/tcp
       - 9090/tcp
+      - 61616/tcp
     published_ports:
       - 0.0.0.0:80:80/tcp
       - 0.0.0.0:443:443/tcp
@@ -48,6 +49,7 @@ platforms:
       - 0.0.0.0:8099:8099/tcp
       - 0.0.0.0:8983:8983/tcp
       - 0.0.0.0:9090:9090/tcp
+      - 0.0.0.0:61616:61616/tcp
 provisioner:
   name: ansible
   ansible_args:

--- a/roles/transformers/tasks/main.yml
+++ b/roles/transformers/tasks/main.yml
@@ -176,31 +176,34 @@
   register: download_result
   until: download_result is succeeded
 
-- name: Check for ATS_HOME in "{{ config_folder }}/setenv.sh"
-  shell: cat {{ config_folder }}/setenv.sh | grep ATS_HOME
-  register: test_ats_home
-  failed_when: false
-  changed_when: test_ats_home.rc != 0
-
 - name: Add paths to setenv file
-  become: true
-  become_user: "{{ username }}"
-  blockinfile:
-    path: "{{ config_folder }}/setenv.sh"
-    marker: "# {mark} ATS ENV VARS"
-    block: |
-      export LIBREOFFICE_HOME={{ libreoffice_home }}
-      export IMAGEMAGICK_HOME={{ imagemagick_home }}
-      export IMAGEMAGICK_DYN=/usr/lib64
-      export IMAGEMAGICK_CONFIG=${IMAGEMAGICK_HOME}/config-Q16HDRI
-      export IMAGEMAGICK_CODERS=${IMAGEMAGICK_HOME}/modules-Q16HDRI/coders
-      export IMAGEMAGICK_EXE=/usr/bin/magick
-      export IMAGEMAGICK_EXE=/usr/bin/convert
-      export ATS_HOME={{ binaries_folder }}/transform-service
-      export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
-      export ATS_SHARED_FS_HOST={{ sfs_host }}
-    insertafter: EOF
-  when: test_ats_home.rc != 0
+  block:
+    - name: Add ats common vars to setenv file
+      become: true
+      become_user: "{{ username }}"
+      blockinfile:
+        path: "{{ config_folder }}/setenv.sh"
+        marker: "# {mark} ATS COMMON ENV VARS"
+        block: |          
+          export ATS_HOME={{ binaries_folder }}/transform-service
+          export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
+          export ATS_SHARED_FS_HOST={{ sfs_host }}
+        insertafter: EOF
+    - name: Add ats dependencies vars to setenv file
+      become: true
+      become_user: "{{ username }}"
+      blockinfile:
+        path: "{{ config_folder }}/setenv.sh"
+        marker: "# {mark} ATS DEPENDENCIES ENV VARS"
+        block: |          
+          export LIBREOFFICE_HOME={{ libreoffice_home }}
+          export IMAGEMAGICK_HOME={{ imagemagick_home }}
+          export IMAGEMAGICK_DYN=/usr/lib64
+          export IMAGEMAGICK_CONFIG=${IMAGEMAGICK_HOME}/config-Q16HDRI
+          export IMAGEMAGICK_CODERS=${IMAGEMAGICK_HOME}/modules-Q16HDRI/coders
+          export IMAGEMAGICK_EXE=/usr/bin/magick
+          export IMAGEMAGICK_EXE=/usr/bin/convert
+        insertafter: EOF
 
 - name: Create log file with correct permissions
   become: true
@@ -221,6 +224,7 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
+  notify: restart-aio
 
 - name: Add alfresco-tengine-aio service
   become: true
@@ -231,7 +235,7 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-aio
+  notify: reload-aio
 
 - name: clean all
   command: yum clean all
@@ -245,11 +249,4 @@
     wait_for:
       host: "{{ activemq_host }}"
       port: 61616
-    register: activemq_go
-
-- name: Enable and start AIO service
-  systemd:
-    name: alfresco-tengine-aio.service
-    state: started
-    enabled: true
-  when: not activemq_go.failed
+    notify: enable-start-aio

--- a/roles/transformers/tasks/main.yml
+++ b/roles/transformers/tasks/main.yml
@@ -235,7 +235,7 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: reload-aio
+  notify: restart-aio
 
 - name: clean all
   command: yum clean all

--- a/roles/transformers/tasks/main.yml
+++ b/roles/transformers/tasks/main.yml
@@ -214,6 +214,12 @@
     mode: u=rwx,g=rw,o-rwx
   changed_when: false
 
+- name: clean all
+  command: yum clean all
+  args:
+    warn: false
+  changed_when: false
+
 - name: Add AIO startup script
   become: true
   become_user: "{{ username }}"
@@ -224,7 +230,10 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-aio
+  notify: 
+    - get-services
+    - wait-for-activemq
+    - restart-aio
 
 - name: Add alfresco-tengine-aio service
   become: true
@@ -235,18 +244,9 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-aio
-
-- name: clean all
-  command: yum clean all
-  args:
-    warn: false
-  changed_when: false
-
-- name: Getting go_signal tengine-aio service to start
-  block:
-  - name: Check for activemq "{{ activemq_host }}"
-    wait_for:
-      host: "{{ activemq_host }}"
-      port: 61616
-    notify: enable-start-aio
+  notify: 
+    - get-services
+    - wait-for-activemq
+    - enable-aio
+    - start-aio
+    - restart-aio

--- a/roles/trouter/handlers/main.yml
+++ b/roles/trouter/handlers/main.yml
@@ -1,26 +1,35 @@
 ---
 # handlers file for trouter
-- name: restart-trouter
-  service:
-    name: alfresco-transform-router
-    state: restarted
-    daemon_reload: true
+- name: get-services
+  service_facts:
+  register: services_state
 
-- name: reload-trouter
+- name: wait-for-aio
+  wait_for:
+    host: "{{ ats_tengine_aio_host }}"
+    port: 8090
+  register: go_signal
+
+- name: enable-trouter
   service:
     name: alfresco-transform-router
-    state: reloaded
+    enabled: true
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-transform-router.service'].status != 'enabled'
 
 - name: start-trouter
   service:
     name: alfresco-transform-router
     state: started
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-transform-router.service'].state != 'running'
 
-- name: enable-start-trouter
+- name: restart-trouter
   service:
     name: alfresco-transform-router
-    state: started
-    enabled: true
+    state: restarted
+    daemon_reload: true
+  when: not go_signal.failed and services_state.ansible_facts.services['alfresco-transform-router.service'].state == 'running'
 
 - name: stop-trouter
   service:

--- a/roles/trouter/handlers/main.yml
+++ b/roles/trouter/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: alfresco-transform-router
     state: restarted
+    daemon_reload: true
 
 - name: reload-trouter
   service:

--- a/roles/trouter/handlers/main.yml
+++ b/roles/trouter/handlers/main.yml
@@ -4,16 +4,24 @@
   service:
     name: alfresco-transform-router
     state: restarted
-    daemon_reload: true
+
+- name: reload-trouter
+  service:
+    name: alfresco-transform-router
+    state: reloaded
 
 - name: start-trouter
   service:
     name: alfresco-transform-router
     state: started
-    daemon_reload: true
+
+- name: enable-start-trouter
+  service:
+    name: alfresco-transform-router
+    state: started
+    enabled: true
 
 - name: stop-trouter
   service:
     name: alfresco-transform-router
     state: stopped
-    daemon_reload: true

--- a/roles/trouter/molecule/default/converge.yml
+++ b/roles/trouter/molecule/default/converge.yml
@@ -5,9 +5,11 @@
     - name: "Include activemq"
       include_role:
         name: "activemq"
+    - meta: flush_handlers
     - name: "Include AIO"
       include_role:
         name: "transformers"
+    - meta: flush_handlers
     - name: "Include trouter"
       include_role:
         name: "trouter"

--- a/roles/trouter/molecule/default/molecule.yml
+++ b/roles/trouter/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
     - verify
     - side_effect
     - cleanup

--- a/roles/trouter/tasks/main.yml
+++ b/roles/trouter/tasks/main.yml
@@ -41,31 +41,19 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
+  notify: restart-trouter
 
 - name: Add paths to setenv file
-  block:
-    - name: Check for ATS_HOME in "{{ config_folder }}/setenv.sh"
-      shell: cat {{ config_folder }}/setenv.sh | grep ATS_HOME
-      register: test_ats_home
-      failed_when: false
-      changed_when: test_ats_home.rc != 0
-    - name: Check for ACTIVEMQ_HOST in "{{ config_folder }}/setenv.sh"
-      shell: cat {{ config_folder }}/setenv.sh | grep ACTIVEMQ_HOST
-      register: test_activemq_home
-      failed_when: false
-      changed_when: test_activemq_home.rc != 0
-    - name: Add paths to setenv file
-      become: true
-      become_user: "{{ username }}"
-      blockinfile:
-        path: "{{ config_folder }}/setenv.sh"
-        marker: "# {mark} ROUTER ENV VARS"
-        block: |
-          export ATS_HOME={{ binaries_folder }}/transform-service
-          export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
-          export ATS_SHARED_FS_HOST={{ sfs_host }}
-        insertafter: EOF
-      when: test_ats_home.rc != 0 and test_activemq_home.rc != 0
+  become: true
+  become_user: "{{ username }}"
+  blockinfile:
+    path: "{{ config_folder }}/setenv.sh"
+    marker: "# {mark} ATS COMMON ENV VARS"
+    block: |
+      export ATS_HOME={{ binaries_folder }}/transform-service
+      export ATS_TENGINE_AIO_HOST={{ ats_tengine_aio_host }}
+      export ATS_SHARED_FS_HOST={{ sfs_host }}
+    insertafter: EOF
 
 - name: Create log file with correct permissions
   become: true
@@ -85,7 +73,7 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-trouter
+  notify: reload-trouter
 
 - name: clean all
   command: yum clean all
@@ -97,11 +85,4 @@
   wait_for:
     host: "{{ ats_tengine_aio_host }}"
     port: 8090
-  register: go_signal
-
-- name: Enable and start t-router service
-  systemd:
-    name: alfresco-transform-router.service
-    state: started
-    enabled: true
-  when: not go_signal.failed
+  notify: enable-start-trouter

--- a/roles/trouter/tasks/main.yml
+++ b/roles/trouter/tasks/main.yml
@@ -41,7 +41,9 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-trouter
+  notify:
+    - get-services
+    - restart-trouter
 
 - name: Add paths to setenv file
   become: true
@@ -64,6 +66,12 @@
     mode: u=rwx,g=rw,o-rwx
   changed_when: false
 
+- name: clean all
+  command: yum clean all
+  args:
+    warn: false
+  changed_when: false
+
 - name: Add alfresco-transform-router service
   become: true
   template:
@@ -73,16 +81,9 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: restart-trouter
-
-- name: clean all
-  command: yum clean all
-  args:
-    warn: false
-  changed_when: false
-
-- name: Getting go_signal for t-router to start
-  wait_for:
-    host: "{{ ats_tengine_aio_host }}"
-    port: 8090
-  notify: enable-start-trouter
+  notify:
+    - get-services
+    - wait-for-aio
+    - enable-trouter
+    - start-trouter
+    - restart-trouter

--- a/roles/trouter/tasks/main.yml
+++ b/roles/trouter/tasks/main.yml
@@ -73,7 +73,7 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'
     force: true
-  notify: reload-trouter
+  notify: restart-trouter
 
 - name: clean all
   command: yum clean all


### PR DESCRIPTION
Work done
- Replaced usage of ```systemd``` with ```service``` module as is more general (supported init systems include BSD init, OpenRC, SysV, Solaris SMF, systemd, upstart. [docs](https://docs.ansible.com/ansible/2.9/modules/service_module.html#ansible-collections-ansible-builtin-service-module))
- created and/or renamed handlers that describe the state of a service when they are notified. all handlers have consistent names. Now ansible displays the states of the services at the end of each role. Now all handlers are notified and the logic of deciding the state of the service is in the handlers file. Example bellow:

```
- name: Add activemq.service
  template:
    src: activemq.service
    dest: /etc/systemd/system/activemq.service
    owner: "{{ username }}"
    group: "{{ group_name }}"
    mode: 'u=rwx,g=rwx,o=rx'
  notify:
    - get-services
    - enable-activemq
    - start-activemq
    - restart-activemq
```

```   
RUNNING HANDLER [../roles/activemq : get-services] ***********************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [activemq_1]

RUNNING HANDLER [../roles/activemq : enable-activemq] ********************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [activemq_1]

RUNNING HANDLER [../roles/activemq : start-activemq] *********************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [activemq_1]

RUNNING HANDLER [../roles/activemq : restart-activemq] *******************************************************************************************************************************************************************************************************************************************************************************************************************
skipping: [activemq_1]
``` 



- as per [OPSEXP-740](https://alfresco.atlassian.net/browse/OPSEXP-740) I changed the download location of activemq archive to ```/tmp/ansible_artefacts/``` . added ```idempotence``` test to molecule test sequence
- simplified the logic that writes env variables in setenv file for ```transformers```, ```sfs``` and ```trouter``` roles
- fixed ```search```, ```sfs```, ```tomcat```, ```trouter```  roles idempotency.