### PR TITLE
OPSEXP-846: Update ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
     - /OPSEXP-.*/
 
 before_install:
-  - pip install ansible==2.9.16 molecule==3.0.8 ansible-lint PyHamcrest pylint pytest-testinfra
+  - pip install ansible==2.9.18 molecule==3.0.8 ansible-lint PyHamcrest pylint pytest-testinfra
 
 env:
   - MOLECULE_NO_LOG=false
@@ -138,7 +138,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el7.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "export NEXUS_USERNAME=$NEXUS_USERNAME; export NEXUS_PASSWORD=\"$NEXUS_PASSWORD\"; cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@6.2.N-extra-vars.yml\""
@@ -170,7 +170,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el8.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "export NEXUS_USERNAME=$NEXUS_USERNAME; export NEXUS_PASSWORD=\"$NEXUS_PASSWORD\"; cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@tests/test-extra-vars.yml\""
@@ -202,7 +202,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el8.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@community-extra-vars.yml\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
     - /OPSEXP-.*/
 
 before_install:
-  - pip install ansible==2.9.18 molecule==3.0.8 ansible-lint PyHamcrest pylint pytest-testinfra
+  - pip install ansible==${ANSIBLE_VERSION} molecule==3.0.8 ansible-lint PyHamcrest pylint pytest-testinfra
 
 env:
   - MOLECULE_NO_LOG=false
@@ -138,7 +138,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el7.noarch"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-${ANSIBLE_VERSION}-1.el7.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "export NEXUS_USERNAME=$NEXUS_USERNAME; export NEXUS_PASSWORD=\"$NEXUS_PASSWORD\"; cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@6.2.N-extra-vars.yml\""
@@ -170,7 +170,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el8.noarch"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-${ANSIBLE_VERSION}-1.el8.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "export NEXUS_USERNAME=$NEXUS_USERNAME; export NEXUS_PASSWORD=\"$NEXUS_PASSWORD\"; cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@tests/test-extra-vars.yml\""
@@ -202,7 +202,7 @@ jobs:
         - export VERSION=$(cat VERSION)
         - scp dist/alfresco-ansible-deployment-${VERSION}.zip centos@${PUBLIC_IP}:/home/centos/
         - ssh centos@${PUBLIC_IP} "sudo yum install -y -q unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-2.9.18-1.el8.noarch"
+        - ssh centos@${PUBLIC_IP} "sudo yum update -y -q; sudo yum install -y -q ansible-${ANSIBLE_VERSION}-1.el8.noarch"
         - ssh centos@${PUBLIC_IP} "unzip alfresco-ansible-deployment-${VERSION}.zip"
         - scp -r tests centos@${PUBLIC_IP}:/home/centos/alfresco-ansible-deployment-${VERSION}/
         - ssh centos@${PUBLIC_IP} "cd alfresco-ansible-deployment-${VERSION}; ansible-playbook playbooks/acs.yml -i inventory_local.yml -e \"@community-extra-vars.yml\""

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ The same playbook can be run to deploy the system in several different ways, ple
 
 ## Versioning
 
-The playbooks have been tested with Ansible 2.9.16 on target hosts with the following operating systems:
+The playbooks have been tested with Ansible 2.9.18 on target hosts with the following operating systems:
 
 * CentOS 7 and 8
 * Red Hat Enterprise Linux 7 and 8

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -112,10 +112,10 @@ In the interest of keeping this guide simple we will use an AWS EC2 instance as 
     sudo yum install -y unzip https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     ```
 
-4. Install Ansible
+4. Install Ansible (replace el7 with el8 in the package name if you're using CentOS 8)
 
     ```bash
-    sudo yum install -y ansible
+    sudo yum install -y ansible-2.9.18-1.el7.noarch
     ```
 
 5. Extract the ZIP file

--- a/docs/generate-target-hosts.md
+++ b/docs/generate-target-hosts.md
@@ -19,7 +19,7 @@ Molecule provides support for testing with multiple instances, operating systems
 4. Install ansible, molecule and molecule-ec2, pyyaml on the control node
 
     ```bash
-    sudo pip3 install ansible==2.9.15 molecule==3.0.8 molecule-ec2==0.2 pyyaml
+    sudo pip3 install ansible==2.9.16 molecule==3.0.8 molecule-ec2==0.2 pyyaml
     ```
 
 5. As the scripts are designed to work in our build environment a `TRAVIS_BUILD_NUMBER` and `TRAVIS_BRANCH` environment variable is expected. These can be set to whatever you want, they are used to name the EC2 instances.

--- a/docs/generate-target-hosts.md
+++ b/docs/generate-target-hosts.md
@@ -19,7 +19,7 @@ Molecule provides support for testing with multiple instances, operating systems
 4. Install ansible, molecule and molecule-ec2, pyyaml on the control node
 
     ```bash
-    sudo pip3 install ansible==2.9.16 molecule==3.0.8 molecule-ec2==0.2 pyyaml
+    sudo pip3 install ansible==2.9.18 molecule==3.0.8 molecule-ec2==0.2 pyyaml
     ```
 
 5. As the scripts are designed to work in our build environment a `TRAVIS_BUILD_NUMBER` and `TRAVIS_BRANCH` environment variable is expected. These can be set to whatever you want, they are used to name the EC2 instances.


### PR DESCRIPTION
On travis we have pinned ansible version to 2.9.16, on the control machine we use 2.9.13 and on the ec2 instances created for local install testing we use 2.9.18.
As per ansible [documentation](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-rhel-centos-or-fedora) 2.10 is not available in yum repositories.
Updated and pinned ansible version across the travis build to 2.9.18