### PR TITLE
Code to resolve the issue #219

### DIFF
--- a/roles/sfs/templates/ats-shared-fs.sh
+++ b/roles/sfs/templates/ats-shared-fs.sh
@@ -4,7 +4,7 @@ if [ $(id -u) -eq 0 ]; then
     exit
 fi
 
-. /etc/opt/alfresco/setenv.sh
+. {{ config_folder }}/setenv.sh
 {% for key, value in sfs_environment.items() %}
 export {{key}}="{{value}}"
 {% endfor %}

--- a/roles/sync/templates/syncservice.sh
+++ b/roles/sync/templates/syncservice.sh
@@ -4,7 +4,7 @@ if [ $(id -u) -eq 0 ]; then
     exit
 fi
 
-. /etc/opt/alfresco/setenv.sh
+. {{ config_folder }}/setenv.sh
 
 {% for key, value in sync_environment.items() %}
 {{key}}="{{value}}"

--- a/roles/transformers/templates/ats-ate-aio.sh
+++ b/roles/transformers/templates/ats-ate-aio.sh
@@ -4,7 +4,7 @@ if [ $(id -u) -eq 0 ]; then
     exit
 fi
 
-. /etc/opt/alfresco/setenv.sh
+. {{ config_folder }}/setenv.sh
 export JAVA_OPTS="${JAVA_OPTS} -DPDFRENDERER_EXE={{ ats_home }}/alfresco-pdf-renderer"
 export JAVA_OPTS="${JAVA_OPTS} -DLIBREOFFICE_HOME=${LIBREOFFICE_HOME}"
 export JAVA_OPTS="${JAVA_OPTS} -DIMAGEMAGICK_ROOT=${IMAGEMAGICK_HOME} -DIMAGEMAGICK_DYN=${IMAGEMAGICK_DYN} -DIMAGEMAGICK_EXE=${IMAGEMAGICK_EXE} -DIMAGEMAGICK_CONFIG=${IMAGEMAGICK_CONFIG} -DIMAGEMAGICK_CODERS=${IMAGEMAGICK_CODERS}"

--- a/roles/trouter/templates/ats-atr.sh
+++ b/roles/trouter/templates/ats-atr.sh
@@ -4,7 +4,7 @@ if [ $(id -u) -eq 0 ]; then
     exit
 fi
 
-. /etc/opt/alfresco/setenv.sh
+. {{ config_folder }}/setenv.sh
 export JAVA_OPTS="${JAVA_OPTS} -DCORE_AIO_URL=http://${ATS_TENGINE_AIO_HOST}:{{ ports_cfg.transformers.tengine }}"
 export JAVA_OPTS="${JAVA_OPTS} -DCORE_AIO_QUEUE=org.alfresco.transform.engine.aio.acs"
 export JAVA_OPTS="${JAVA_OPTS} -DACTIVEMQ_URL=failover:(tcp://{{ activemq_host }}:{{ ports_cfg.activemq.openwire }})?timeout=3000"


### PR DESCRIPTION
https://github.com/Alfresco/alfresco-ansible-deployment/issues/219

It is detected that the following "sh" boot files have the path of the "setenv.sh" hard coded without using the ansible configuration path {{ config_folder }}.

The following change is proposed

```bash
## original
. /etc/opt/alfresco/setenv.sh
## change
. {{ config_folder }}/setenv.sh
```

Affected files

- alfresco-ansible-deployment\roles\sfs\templates\ats-shared-fs.sh

- alfresco-ansible-deployment\roles\sync\templates\syncservice.sh

- alfresco-ansible-deployment\roles\transformers\templates\ats-ate-aio.sh

- alfresco-ansible-deployment\roles\trouter\templates\ats-atr.sh