### PR TITLE
OPSEXP-1131 ACS hotfix upgrade

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,7 @@ warn_list:
   - experimental
   - deprecations
 skip_list:
+  - 'risky-file-permissions'
   - 'no-changed-when'
   - 'command-instead-of-module'
   - 'command-instead-of-shell'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-# Byte-compiled / optimized / DLL files
+# project specifics 
+configuration_files/ssl_certificates/
+
+# # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,36 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/pylint
-    rev: pylint-2.5.0
+    rev: v2.12.2
     hooks:
       - id: pylint
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.23.0
+    rev: v1.26.3
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$
         types: [file, yaml]
         entry: yamllint --strict
   - repo: https://github.com/ansible/ansible-lint
-    rev: v5.0.12
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
         entry: ansible-lint -v
         name: ansible-lint
         files: \.(yaml|yml)$
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v1.1.0
     hooks:
       - id: detect-secrets
         name: detect generic secrets
-        args: ['--baseline', '.secrets.baseline']
+        args: ['--baseline', '.secrets.baseline', '--exclude-secrets', '(admin|mp6yc0UD9e)']
   - repo: https://github.com/awslabs/git-secrets
     rev: master
     hooks:
       - id: git-secrets
         name: detect aws secrets
   - repo: https://github.com/milin/giticket
-    rev: 6f166c66f2423e8e27898b39385d1166f9b643a3
+    rev: v1.3
     hooks:
       - id: giticket
         args: ['--regex', '[A-Z]+-\d+[0-9]', '--format', '{ticket}: {commit_msg}', '--mode', 'regex_match']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,11 @@
 ---
 repos:
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.12.2
+    rev: v2.10.2
     hooks:
       - id: pylint
+        types: [file, python]
+        exclude: '__init__.py'
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.26.3
     hooks:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,8 +1,4 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
   "generated_at": "2021-12-15T12:57:17Z",
   "plugins_used": [
     {
@@ -12,8 +8,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -60,142 +56,191 @@
   "results": {
     ".travis.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": ".travis.yml",
         "hashed_secret": "9a09b30f1d1a9aa0c87ddb0528716751359fac71",
         "is_verified": false,
-        "line_number": 260,
-        "type": "Secret Keyword"
+        "line_number": 260
       }
     ],
     "docs/deployment-guide.md": [
       {
+        "type": "Secret Keyword",
+        "filename": "docs/deployment-guide.md",
         "hashed_secret": "852be12b4687d7f017cc1777a909d42d27a6f4d6",
         "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword"
+        "line_number": 62
       }
     ],
     "roles/adw/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/adw/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 20,
-        "type": "Secret Keyword"
+        "line_number": 20
       }
     ],
     "roles/common/vars/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/common/vars/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 7,
-        "type": "Secret Keyword"
+        "line_number": 7
       }
     ],
     "roles/java/vars/main.yml": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "roles/java/vars/main.yml",
         "hashed_secret": "1c078009dee5aa3d8230fcbe714dc8d67a4ee87a",
         "is_verified": false,
-        "line_number": 7,
-        "type": "Hex High Entropy String"
+        "line_number": 7
       }
     ],
     "roles/postgres/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/postgres/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword"
+        "line_number": 68
       }
     ],
     "roles/repository/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 188,
-        "type": "Secret Keyword"
+        "line_number": 188
       }
     ],
     "roles/repository/tasks/postgres.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/tasks/postgres.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 23,
-        "type": "Secret Keyword"
+        "line_number": 23
       }
     ],
     "roles/repository/templates/custom-slingshot-application-context.xml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/templates/custom-slingshot-application-context.xml",
         "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
         "is_verified": false,
-        "line_number": 22,
-        "type": "Secret Keyword"
+        "line_number": 22
       }
     ],
     "roles/repository/vars/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/vars/main.yml",
         "hashed_secret": "5d34c7b23b71ee42fff7d26fda1244af871de814",
         "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword"
+        "line_number": 26
       }
     ],
     "roles/repository/vars/postgres.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/vars/postgres.yml",
         "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
         "is_verified": false,
-        "line_number": 5,
-        "type": "Secret Keyword"
+        "line_number": 5
       }
     ],
     "roles/search/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/search/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 36,
-        "type": "Secret Keyword"
+        "line_number": 36
       }
     ],
     "roles/search/templates/solr.in.sh": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/search/templates/solr.in.sh",
         "hashed_secret": "9af6ef1418e607eb12916e773e5634da224addb1",
         "is_verified": false,
-        "line_number": 143,
-        "type": "Secret Keyword"
+        "line_number": 143
       },
       {
+        "type": "Secret Keyword",
+        "filename": "roles/search/templates/solr.in.sh",
         "hashed_secret": "750f420814f2078063ed8a46f74f3ea59ea192fe",
         "is_verified": false,
-        "line_number": 144,
-        "type": "Secret Keyword"
+        "line_number": 144
       }
     ],
     "roles/sfs/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/sfs/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 30,
-        "type": "Secret Keyword"
+        "line_number": 30
       }
     ],
     "roles/transformers/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/transformers/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 102,
-        "type": "Secret Keyword"
+        "line_number": 102
       }
     ],
     "roles/trouter/tasks/main.yml": [
       {
+        "type": "Secret Keyword",
+        "filename": "roles/trouter/tasks/main.yml",
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
         "is_verified": false,
-        "line_number": 33,
-        "type": "Secret Keyword"
+        "line_number": 33
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "version": "1.1.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/docs/components-upgrade.md
+++ b/docs/components-upgrade.md
@@ -59,6 +59,9 @@ acs:
 ...
 ```
 
+> IMPORTANT: make sure you do not set the version to a version number that's not a hotfix (version number needs to be 4 digits and the 3 first ones needs to match the ones of the initially deployed version)
+> This is because, as eplained earlier, "in-place" upgrades are only supported for hotfixes
+
 Once these changes are saved run the command bellow:
 
 ```

--- a/docs/components-upgrade.md
+++ b/docs/components-upgrade.md
@@ -37,9 +37,9 @@ Alfresco also releases some hotfixes and an hotfix upgrade would be moving from 
 
 In order to apply a later hotfix, you need to first match the pre-requisites, then change the ACS version to point to the hotfix version in the appropriate file, and finally run the playbook again.
 
-In the example bellow we want to upgrade from the initial 7.0.1 installtion to 7.0.1.4 hotfix:
+In the example bellow we want to upgrade from the initial 7.0.1 installation to 7.0.1.4 hotfix:
 
-Edit `7.0.N-extra-vars.yml` and changes the the bellow snippet
+Edit `7.0.N-extra-vars.yml` and changes the the bellow snippet:
 
 ```
 ---           
@@ -49,7 +49,7 @@ acs:
 ...
 ```
 
-to
+to:
 
 ```
 ---           

--- a/docs/components-upgrade.md
+++ b/docs/components-upgrade.md
@@ -1,0 +1,77 @@
+# Upgrading an environment
+
+The ACS installation is made of several components among which:
+
+ - Content service
+ - share
+ - digital workspace
+ - Search service
+ - ...
+
+## Pre-requisites
+
+Before proceeding to an upgrade, an administrator needs to:
+
+ * Make sure the [upgrade path and documentation](https://docs.alfresco.com/content-services/latest/upgrade/) is followed
+
+ * Appropriate backups of database, contentstore and indexes are done and can be restored in case a rollback is needed
+
+ * Initial deployment must have been done using this Ansible playbook
+
+## Supported Components
+
+### Content service
+
+#### Upgrade types
+
+There are different kinds of upgrade one may want to proceed. For example a major upgrade would be upgrading from 7.0.x to 7.1.x.
+A minor upgrade (or service pack upgrade) would be moving from 7.0.0 to 7.0.1.
+Both major and minor upgrades require setting up a new environment and porting data and customizations from the source environment to the target one. The main reason behind this limitation is that major upgrades usually come with underlying software stack changes.
+These migrations cannot be done "in-place".
+
+Alfresco also releases some hotfixes and an hotfix upgrade would be moving from 7.0.1 to 7.0.1.4. This type of upgrade can be done "in-place" and is supported by the playbook.
+
+> Please note that "in-place" upgrade still need to match the upgrade pre-requisites
+
+#### Proceeding to an "in-place" hotfix upgrade
+
+In order to apply a later hotfix, you need to first match the pre-requisites, then change the ACS version to point to the hotfix version in the appropriate file, and finally run the playbook again.
+
+In the example bellow we want to upgrade from the initial 7.0.1 installtion to 7.0.1.4 hotfix:
+
+Edit `7.0.N-extra-vars.yml` and changes the the bellow snippet
+
+```
+---           
+acs:         
+  version: 7.0.1
+  edition: Enterprise 
+...
+```
+
+to
+
+```
+---           
+acs:         
+  version: 7.0.1.4
+  edition: Enterprise 
+...
+```
+
+Once these changes are saved run the command bellow:
+
+```
+ansible-playbook playbooks/acs.yml -i inventory_ssh.yml -e "@7.0.N-extra-vars.yml"
+```
+
+> Note: Use whatever inventory and config file that matches your use case
+> If you're applying a hotfix to the latest major release (7.1 as of writing) you don't need to specify an extra config file with "-e @file"
+
+After the playbook ran successfully your environment delivers the upgraded version of repo.
+
+## Upgrade impacts
+
+### Hotfix "in-place" upgrades
+
+This process will restart tomcat on all the repository nodes and there is no guarantee one node is stopped only after the others have restarted. As a consequence a short service outage needs to be scheduled

--- a/docs/components-upgrade.md
+++ b/docs/components-upgrade.md
@@ -33,7 +33,7 @@ Alfresco also releases some hotfixes and an hotfix upgrade would be moving from 
 
 > Please note that "in-place" upgrade still need to match the upgrade pre-requisites
 
-#### Proceeding to an "in-place" hotfix upgrade
+#### Proceeding to a hotfix "in-place" upgrade
 
 In order to apply a later hotfix, you need to first match the pre-requisites, then change the ACS version to point to the hotfix version in the appropriate file, and finally run the playbook again.
 
@@ -71,7 +71,15 @@ ansible-playbook playbooks/acs.yml -i inventory_ssh.yml -e "@7.0.N-extra-vars.ym
 > Note: Use whatever inventory and config file that matches your use case
 > If you're applying a hotfix to the latest major release (7.1 as of writing) you don't need to specify an extra config file with "-e @file"
 
-After the playbook ran successfully your environment delivers the upgraded version of repo.
+After the playbook ran successfully your environment delivers the upgraded version of repo but the previous installation is still on the target machine. It is the admin responsability to make sure the new system works as expected and no rollback is needed. If all is OK, the old installation previous installation can be cleaned by removing the folder: `{{ binaries_folder }}/content-services-{{ acs.version }}` (by default points to: `/opt/alfresco/content-services-7.0.1`).
+
+#### Rolling back a hotfix "in-place" upgrade
+
+If something goes wrong with the upgrade, or if tests are not successful after upgrade completed, rolling back the environment can be done by following the steps bellow:
+
+ - restoring Database and contentstore backup
+ - reverting the version changes to previous state in the config file (either `group_vars/all` or version specific config files)
+ - running the playbook again.
 
 ## Upgrade impacts
 

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -20,6 +20,18 @@
   become: true
   roles:
     - role: '../roles/transformers'
+  post_tasks:
+    - name: update installation status file with Transformers
+      vars:
+        transform_components:
+          transform:
+            "{{ transform }}"
+      blockinfile:
+        block: "{{ transform_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: TRANSFORM_BEGIN
+        marker_end: TRANSFORM_END
   tags:
     - transformers
 
@@ -28,6 +40,18 @@
   become: true
   roles:
     - role: '../roles/search'
+  post_tasks:
+    - name: update installation status file with  Search
+      vars:
+        search_components:
+          search:
+            "{{ search }}"
+      blockinfile:
+        block: "{{ search_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: SEARCH_BEGIN
+        marker_end: SEARCH_END
   tags:
     - search
 
@@ -36,6 +60,22 @@
   become: true
   roles:
     - role: '../roles/repository'
+  post_tasks:
+    - name: update installation status file with ACS
+      vars:
+        acs_components:
+          acs:
+            "{{ acs }}"
+          amps:
+            "{{ amps }}"
+          api_explorer: 
+            "{{ api_explorer }}"
+      blockinfile:
+        block: "{{ acs_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: ACS_BEGIN
+        marker_end: ACS_END
   tags:
     - repository
 
@@ -44,6 +84,18 @@
   become: true
   roles:
     - { role: '../roles/trouter', when: acs.edition == "Enterprise" }
+  post_tasks:
+    - name: update installation status file with Trouter
+      vars:
+        trouter_components:
+          trouter:
+            "{{ trouter }}"
+      blockinfile:
+        block: "{{ trouter_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: TROUTER_BEGIN
+        marker_end: TROUTER_END
   tags:
     - trouter
 
@@ -52,6 +104,18 @@
   become: true
   roles:
     - { role: '../roles/sfs', when: acs.edition == "Enterprise" }
+  post_tasks:
+    - name: update installation status file with SFS
+      vars:
+        sfs_components:
+         sfs:
+            "{{ sfs }}"
+      blockinfile:
+        block: "{{ sfs_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: SFS_BEGIN
+        marker_end: SFS_END
   tags:
     - sfs
 
@@ -60,6 +124,18 @@
   become: true
   roles:
     - { role: '../roles/sync', when: acs.edition == "Enterprise" }
+  post_tasks:
+    - name: update installation status file with Sync
+      vars:
+        sync_components:
+         sync:
+            "{{ sync }}"
+      blockinfile:
+        block: "{{ sync_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: SYNC_BEGIN
+        marker_end: SYNC_END
   tags:
     - sync
 
@@ -76,5 +152,17 @@
   become: true
   roles:
     - { role: '../roles/adw', when: acs.edition == "Enterprise" }
+  post_tasks:
+    - name: update installation status file with ADW
+      vars:
+        adw_components:
+          adw:
+            "{{ adw }}"
+      blockinfile:
+        block: "{{ adw_components | to_nice_yaml(indent=2) }}"
+        create: yes
+        path: "{{ ansible_installation_status_file }}"
+        marker_begin: ADW_BEGIN
+        marker_end: ADW_END
   tags:
     - adw

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jmespath==0.10.0
 molecule==3.0.8
 molecule-docker==0.2.4
 PyHamcrest==2.0.2
-pylint==2.12.2
+pylint==2.10.2
 pytest-testinfra==6.3.0
 requests==2.25.1
 yamllint==1.26.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-ansible-lint==5.0.12
+ansible-lint==5.3.2
 jmespath==0.10.0
 molecule==3.0.8
 molecule-docker==0.2.4
 PyHamcrest==2.0.2
-pylint==2.10.2
+pylint==2.12.2
 pytest-testinfra==6.3.0
 requests==2.25.1
-yamllint==1.26.1
+yamllint==1.26.3
 pyyaml==5.4.1

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -55,3 +55,5 @@ os_fallback:
   - ../vars/{{ ansible_distribution }}.yml
   - ../vars/{{ ansible_os_family }}.yml
   - ../vars/{{ ansible_system }}.yml
+
+ansible_installation_status_file: "{{ binaries_folder }}/.ansible_alfresco_components.status"

--- a/roles/common/tasks/check_upgrades.yml
+++ b/roles/common/tasks/check_upgrades.yml
@@ -58,7 +58,7 @@
           - installed_components.search is defined
           - search != installed_components.search
 
-    - name: Fail on unsupported Sync  upgrades
+    - name: Fail on unsupported Sync upgrades
       fail:
       when:
           - installed_components.sync is defined

--- a/roles/common/tasks/check_upgrades.yml
+++ b/roles/common/tasks/check_upgrades.yml
@@ -8,7 +8,7 @@
 
 - name: read installed versions
   include_vars: 
-    file: /tmp/{{ inventory_hostname }}/{{ansible_installation_status_file }}
+    file: /tmp/{{ inventory_hostname }}/{{ ansible_installation_status_file }}
     name: installed_components
   when: ansible_components_status.msg is undefined
 

--- a/roles/common/tasks/check_upgrades.yml
+++ b/roles/common/tasks/check_upgrades.yml
@@ -52,7 +52,7 @@
         - installed_components.sfs is defined
         - sfs != installed_components.sfs
           
-    - name: Fail on unsupported Search  upgrades
+    - name: Fail on unsupported Search upgrades
       fail:
       when:
           - installed_components.search is defined

--- a/roles/common/tasks/check_upgrades.yml
+++ b/roles/common/tasks/check_upgrades.yml
@@ -1,0 +1,73 @@
+---
+- name: Get Alfresco Ansible status file
+  fetch:
+    src: "{{ ansible_installation_status_file }}"
+    fail_on_missing: no
+    dest: /tmp/
+  register: ansible_components_status
+
+- name: read installed versions
+  include_vars: 
+    file: /tmp/{{ inventory_hostname }}/{{ansible_installation_status_file }}
+    name: installed_components
+  when: ansible_components_status.msg is undefined
+
+- name: Check for invalid components upgrades
+  block:
+    - name: Fail on unsupported ACS upgrade
+      fail:
+      when: |
+        installed_components.acs is defined and
+        installed_components.amps is defined and
+        installed_components.api_explorer is defined and
+        ( 
+          acs.edition != installed_components.acs.edition or
+          acs.version.split('.')[:3] | join('.') != installed_components.acs.version.split('.')[:3] | join('.') or
+          acs.version is version(installed_components.acs.version, 'lt') or
+          amps != installed_components.amps or
+          api_explorer != installed_components.api_explorer
+        )
+
+    - name: Fail on unsupported ADW upgrades
+      fail:
+      when:
+          - installed_components.adw is defined
+          - adw != installed_components.adw 
+
+    - name: Fail on unsupported Transformers upgrades
+      fail:
+      when:
+        - installed_components.transform is defined
+        - transform != installed_components.transform
+
+    - name: Fail on unsupported Trouter upgrades
+      fail:
+      when:
+        - installed_components.trouter is defined
+        - trouter != installed_components.trouter
+
+    - name: Fail on unsupported SFS upgrades
+      fail:
+      when:
+        - installed_components.sfs is defined
+        - sfs != installed_components.sfs
+          
+    - name: Fail on unsupported Search  upgrades
+      fail:
+      when:
+          - installed_components.search is defined
+          - search != installed_components.search
+
+    - name: Fail on unsupported Sync  upgrades
+      fail:
+      when:
+          - installed_components.sync is defined
+          - sync != installed_components.sync
+  any_errors_fatal: true
+  module_defaults:
+    fail:
+      msg: >
+        You're trying to upgrade in an unsupported manner!
+        Please read our documentation for more informations on what's supported and what isn't.
+        https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/docs/components-upgrade.md
+      

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for common
+- name: Check for upgrades
+  import_tasks: check_upgrades.yml
+
 - name: Include OS specific variables
   include_vars: "{{ item }}"
   loop: "{{ lookup('first_found', os_fallback, errors='ignore', wantlist=True) }}"

--- a/roles/repository/molecule/default/converge.yml
+++ b/roles/repository/molecule/default/converge.yml
@@ -3,11 +3,13 @@
   hosts: all
   tasks:
     - name: Add custom global properties settings
-      local_action:
-        module: shell echo "\nftp.enabled=true\nftp.port=1121\nindex.recovery.mode=NONE\nindex.subsystem.name=noindex" >> {{ playbook_dir }}/../../../../configuration_files/alfresco-global.properties
+      shell:
+        cmd: echo "\nftp.enabled=true\nftp.port=1121\nindex.recovery.mode=NONE\nindex.subsystem.name=noindex" >> {{ playbook_dir }}/../../../../configuration_files/alfresco-global.properties
+      delegate_to: localhost
     - name: Create keystore
-      local_action:
-        module: shell keytool -genseckey -dname 'CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB' -validity 30 -alias metadata -keyalg AES -keysize 256 -keystore {{ playbook_dir }}/../../../../configuration_files/keystores/keystest -storetype pkcs12 -storepass mp6yc0UD9e
+      shell:
+        cmd: keytool -genseckey -dname 'CN=Alfresco Repository, OU=Unknown, O=Alfresco Software Ltd., L=Maidenhead, ST=UK, C=GB' -validity 30 -alias metadata -keyalg AES -keysize 256 -keystore {{ playbook_dir }}/../../../../configuration_files/keystores/keystest -storetype pkcs12 -storepass mp6yc0UD9e
+      delegate_to: localhost
     - name: "Include postgres"
       include_role:
         name: "postgres"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -372,22 +372,6 @@
     owner: "{{ username }}"
     group: "{{ group_name }}"
 
-- name: Add PostResources to alfresco.xml
-  become: true
-  become_user: root
-  lineinfile:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/alfresco.xml"
-    regexp: '<PostResources base='
-    line: '<PostResources base="/opt/alfresco/modules/acs-platform"'
-
-- name: Add PostResources to share.xml
-  become: true
-  become_user: root
-  lineinfile:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/share.xml"
-    regexp: '<PostResources base='
-    line: '<PostResources base="/opt/alfresco/modules/acs-share"'
-
 - name: Insert or Update custom properties added through configuration_files/alfresco-global.properties
   blockinfile:
     path: "{{ settings_folder }}/classpath/alfresco-global.properties"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -21,8 +21,6 @@
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rx,o=rx'
   loop:
-     - "{{ binaries_folder }}/modules/acs-platform"
-     - "{{ binaries_folder }}/modules/acs-share"
      - "{{ content_folder }}/modules/acs-platform"
      - "{{ content_folder }}/modules/acs-share"
      - "{{ content_folder }}/amps_repo"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -282,79 +282,33 @@
         path: "{{ content_folder }}/shared/classes/"
         state: absent
 
-- name: Move conf folder
+- name: Create web application config files
   block:
-    - name: Check if conf files exist
-      stat:
-        path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/alfresco.xml"
-      register: conf_exists
-    - name: Copy conf
-      become: true
-      copy:
-        remote_src: true
-        src: "{{ content_folder }}/web-server/conf/Catalina/localhost/"
-        dest: "{{ tomcat_config_dir }}/conf/Catalina/localhost/"
+    - name: Create config folders
+      file:
+        state: directory
+        path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/"
+        mode: 0755
         owner: "{{ username }}"
         group: "{{ group_name }}"
-      when: not conf_exists.stat.exists
+    - name: Create config files
+      template:
+        src: "{{ item }}.xml"
+        dest: "{{ tomcat_config_dir }}/conf/Catalina/localhost/{{ item }}.xml"
+        owner: "{{ username }}"
+        group: "{{ group_name }}"
+        mode: 0644
+      loop:
+        - alfresco
+        - share
+        - ROOT
+        - _vti_bin
+        - api-explorer
     - name: Remove conf files
       file:
         path: "{{ content_folder }}/web-server/conf"
         state: absent
-
-- name: Add context home to alfresco.xml
-  lineinfile:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/alfresco.xml"
-    regexp: '<Context crossContext="true">'
-    line: '<Context crossContext="true" docBase="{{ content_folder }}/web-server/webapps/alfresco.war">'
-
-- name: Add context home to share.xml
-  lineinfile:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/share.xml"
-    regexp: '<Context crossContext="true">'
-    line: '<Context crossContext="true" cachingAllowed="true" cacheMaxSize="100000" docBase="{{ content_folder }}/web-server/webapps/share.war">'
-
-- name: Check if "{{ tomcat_config_dir }}/conf/Catalina/localhost/ROOT.xml" exists
-  stat:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/ROOT.xml"
-  register: root_xml
-
-- name: Create ROOT.xml
-  template:
-    owner: "{{ username }}"
-    group: "{{ group_name }}"
-    src: ROOT.xml
-    dest: "{{ tomcat_config_dir }}/conf/Catalina/localhost/ROOT.xml"
-    mode: 'u=rwx,g=rwx,o=rx'
-  when: not root_xml.stat.exists
-
-- name: Check if "{{ tomcat_config_dir }}/conf/Catalina/localhost/_vti_bin.xml" exists
-  stat:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/_vti_bin.xml"
-  register: vti_xml
-
-- name: Create _vti_bin.xml
-  template:
-    owner: "{{ username }}"
-    group: "{{ group_name }}"
-    src: _vti_bin.xml
-    dest: "{{ tomcat_config_dir }}/conf/Catalina/localhost/_vti_bin.xml"
-    mode: 'u=rwx,g=rwx,o=rx'
-  when: not vti_xml.stat.exists
-
-- name: Check if "{{ tomcat_config_dir }}/conf/Catalina/localhost/api-explorer.xml" exists
-  stat:
-    path: "{{ tomcat_config_dir }}/conf/Catalina/localhost/api-explorer.xml"
-  register: api_explorer_xml
-
-- name: Create api-explorer.xml
-  template:
-    owner: "{{ username }}"
-    group: "{{ group_name }}"
-    src: api-explorer.xml
-    dest: "{{ tomcat_config_dir }}/conf/Catalina/localhost/api-explorer.xml"
-    mode: 'u=rwx,g=rwx,o=rx'
-  when: not api_explorer_xml.stat.exists
+  become: true
 
 - name: Create alfresco-global.properties
   template:

--- a/roles/repository/templates/alfresco.xml
+++ b/roles/repository/templates/alfresco.xml
@@ -1,0 +1,6 @@
+<Context crossContext="true" docBase="{{ content_folder }}/web-server/webapps/alfresco.war">
+	<Resources>
+		<PostResources base="{{ content_folder }}/modules/acs-platform"
+		className="org.apache.catalina.webresources.DirResourceSet" webAppMount="/WEB-INF/lib"/>
+	</Resources>
+</Context>

--- a/roles/repository/templates/share.xml
+++ b/roles/repository/templates/share.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Context crossContext="true" cachingAllowed="true" cacheMaxSize="100000" docBase="{{ content_folder }}/web-server/webapps/share.war">
+  <Resources>
+    <PostResources base="{{ content_folder }}/modules/acs-share"
+                   className="org.apache.catalina.webresources.DirResourceSet"
+                   webAppMount="/WEB-INF/lib"/>
+  </Resources>
+</Context>


### PR DESCRIPTION
Allow Ansible playbook to proceed to "in-place" upgrades for hotfixes
Previous tasks were using "lineinfile" module which can be tricky to use for formats like xml and idempotency.
Replaced by templates

Ref. OPSEXP-1131