### PR TITLE
OPSEXP-1057 Revert to centos:7 for molecule roles tests

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/activemq/molecule/default/molecule.yml
+++ b/roles/activemq/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/adw/molecule/default/molecule.yml
+++ b/roles/adw/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/repository/molecule/default/molecule.yml
+++ b/roles/repository/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/search/molecule/default/molecule.yml
+++ b/roles/search/molecule/default/molecule.yml
@@ -17,7 +17,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/sfs/molecule/default/molecule.yml
+++ b/roles/sfs/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/sync/molecule/default/molecule.yml
+++ b/roles/sync/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/tomcat/molecule/default/molecule.yml
+++ b/roles/tomcat/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/transformers/molecule/default/molecule.yml
+++ b/roles/transformers/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run

--- a/roles/trouter/molecule/default/molecule.yml
+++ b/roles/trouter/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: centos:8
+    image: centos:7
     privileged: true
     tmpfs:
       - /run


### PR DESCRIPTION
OPSEXP-1057

Centos:8 has been removed from mirrors since today, needs to stick back to centos:7