### PR TITLE
[minor] dependabot: limit concurrent PRs to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
avoid spamming travis with many concurrent builds