### PR TITLE
OPSEXP-1264 Fix S3 artifact upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,8 +274,7 @@ jobs:
         secret_access_key: "${STAGING_AWS_SECRET_KEY}"
         bucket: "${S3_STAGING_BUCKET}"
         region: "eu-west-1"
+        skip_cleanup: true
         local_dir: dist
         glob: "*.zip"
         upload-dir: "enterprise/alfresco-ansible-deployment"
-      after_deploy:
-        - rm -fv dist/alfresco-ansible-release-*.zip


### PR DESCRIPTION
OPSEXP-1264

skip_cleanup is quite mandatory when uploading S3 artifacts (all the [examples](https://docs.travis-ci.com/user/deployment/s3/) include it)