### PR TITLE
[minor] Fix vagrant up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ pass     = ENV['NEXUS_PASSWORD']
 
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
-  config.vm.network "private_network", ip: "172.100.100.100"
+  config.vm.network "private_network", ip: "192.168.56.100"
   config.vm.provider "virtualbox" do |v|
     v.memory = 10240
     v.cpus = 4


### PR DESCRIPTION
Running `vagrant up` fails with:

```
==> default: Clearing any previously set network interfaces...
The IP address configured for the host-only network is not within the
allowed ranges. Please update the address used to be within the allowed
ranges and run the command again.

  Address: 172.100.100.100
  Ranges: 192.168.56.0/21

Valid ranges can be modified in the /etc/vbox/networks.conf file. For
more information including valid format see:

  https://www.virtualbox.org/manual/ch06.html#network_hostonly
```