### PR TITLE
OPSEXP-1319 Fix random failure on async download repository task

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -350,6 +350,7 @@
     - molecule-idempotence-notest
 
 - name: Check on postgres download async task
+  become: true
   async_status:
     jid: "{{ postgresql_download.ansible_job_id }}"
   register: job_result
@@ -361,6 +362,7 @@
     - molecule-idempotence-notest
 
 - name: Check on war download async task
+  become: true
   async_status:
     jid: "{{ item.ansible_job_id }}"
   register: job_result


### PR DESCRIPTION
OPSEXP-1319

reintroduce privilege escalation for async download job checks that got removed in https://github.com/Alfresco/alfresco-ansible-deployment/pull/243