### PR TITLE
Bump tomcat to 9.0.59 due to CVE-2022-23181

### DIFF
--- a/6.2.N-extra-vars.yml
+++ b/6.2.N-extra-vars.yml
@@ -28,4 +28,4 @@ dependencies_version:
   activemq: 5.15.14
   jdk: 11.0.13
   jdk_arch: 8
-  tomcat: 8.5.72
+  tomcat: 8.5.76

--- a/7.0.N-extra-vars.yml
+++ b/7.0.N-extra-vars.yml
@@ -30,4 +30,4 @@ dependencies_version:
   activemq: 5.16.1
   jdk: 11.0.13
   jdk_arch: 8
-  tomcat: 9.0.54
+  tomcat: 9.0.59

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ The table below shows the version of the components deployed by the playbook for
 | Component | 7.1 Enterprise | 7.0.N Enterprise | 6.2.N Enterprise | Community |
 |-|-|-|-|-|
 | OpenJDK | 11.0.13 | 11.0.13 | 11.0.13 | 11.0.13 |
-| Apache Tomcat | 9.0.59 | 9.0.54 | 8.5.72 | 9.0.59 |
+| Apache Tomcat | 9.0.59 | 9.0.59 | 8.5.76 | 9.0.59 |
 | PostgreSQL | 13.x | 13.x | 11.x | 13.x |
 | Apache ActiveMQ | 5.16.1 | 5.16.1 | 5.15.14 | 5.16.1 |
 | Repository | 7.1.1 | 7.0.1.4 | 6.2.2 | 7.1.1.2 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ The table below shows the version of the components deployed by the playbook for
 | Component | 7.1 Enterprise | 7.0.N Enterprise | 6.2.N Enterprise | Community |
 |-|-|-|-|-|
 | OpenJDK | 11.0.13 | 11.0.13 | 11.0.13 | 11.0.13 |
-| Apache Tomcat | 9.0.54 | 9.0.54 | 8.5.72 | 9.0.54 |
+| Apache Tomcat | 9.0.59 | 9.0.54 | 8.5.72 | 9.0.59 |
 | PostgreSQL | 13.x | 13.x | 11.x | 13.x |
 | Apache ActiveMQ | 5.16.1 | 5.16.1 | 5.15.14 | 5.16.1 |
 | Repository | 7.1.1 | 7.0.1.4 | 6.2.2 | 7.1.1.2 |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -109,7 +109,7 @@ dependencies_version:
   activemq: 5.16.1
   jdk: 11.0.13
   jdk_arch: 8
-  tomcat: 9.0.54
+  tomcat: 9.0.59
 
 apache_archive_url: https://archive.apache.org
 tomcat_archive_url: "{{ apache_archive_url}}/dist/tomcat"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -49,7 +49,7 @@
     group: "{{ group_name }}"
     mode: 'u=rw,g=r,o=r'
   register: distribution_download_result
-  async: 900
+  async: 1800
   poll: 0
   tags:
     - molecule-idempotence-notest
@@ -130,8 +130,8 @@
   async_status:
     jid: "{{ distribution_download_result.ansible_job_id }}"
   until: job_result.finished
-  delay: 30
-  retries: 20
+  delay: 10
+  retries: 180
   register: job_result
   tags:
     - molecule-idempotence-notest


### PR DESCRIPTION
OPSEXP-1316