### PR TITLE
Fix for jmespath conflict with boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jmespath==1.0.0
 molecule==3.6.1
 molecule-docker==1.1.0
 molecule-ec2==0.4
-boto3==1.21.19
+boto3==1.21.22
 PyHamcrest==2.0.3
 pylint==2.12.2
 pytest-testinfra==6.6.0


### PR DESCRIPTION
```
ERROR: Cannot install -r requirements.txt (line 7) and jmespath==1.0.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested jmespath==1.0.0
    boto3 1.21.19 depends on jmespath<1.0.0 and >=0.7.1
```