### PR TITLE
OPSEXP-1328 Retry failing destroy during ec2 tests

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -112,4 +112,9 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.nexus_password }}
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-        run: ./tests/molecule_it/script.sh destroy
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: ./tests/molecule_it/script.sh destroy

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -8,6 +8,11 @@
     - name: Gather EC2 facts
       amazon.aws.ec2_metadata_facts:
       delegate_to: "{{ groups['nginx'] | first }}"
+      ignore_unreachable: yes
+
+    - name: End gracefully if EC2 is unavailable
+      meta: end_host
+      when: ansible_ec2_public_hostname is undefined
 
     - name: Set variables
       set_fact:

--- a/molecule/multimachine/cleanup.yml
+++ b/molecule/multimachine/cleanup.yml
@@ -1,42 +1,13 @@
 ---
-- name: Cleanup
+- name: Default cleanup
+  import_playbook: ../default/cleanup.yml
+
+- name: Multimachine cleanup
   hosts: localhost
   gather_facts: false
   vars:
     project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
   tasks:
-    - name: Gather EC2 facts
-      amazon.aws.ec2_metadata_facts:
-      delegate_to: "{{ groups['nginx'] | first }}"
-
-    - name: "Set variables"
-      set_fact:
-        certificate_domain: "{{ ansible_ec2_public_hostname }}"
-        private_key_path: "{{ project_dir }}/configuration_files/ssl_certificates/{{ ansible_ec2_public_hostname }}.key"
-        cert_path: "{{ project_dir }}/configuration_files/ssl_certificates/{{ ansible_ec2_public_hostname }}.crt"
-
-    - name: cleanup cert
-      delegate_to: localhost
-      file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - "{{ private_key_path }}"
-        - "{{ cert_path }}"
-
-    - name: Reset extra vars file
-      delegate_to: localhost
-      ansible.builtin.replace:
-        path: "{{ project_dir }}/tests/test-ssl.yml"
-        regexp: "{{ certificate_domain }}"
-        replace: TEST_FQDN
-
-    - name: Get EC2 instances info
-      amazon.aws.ec2_instance_info:
-        filters:
-          "tag:Name": molecule_{{ lookup('env', 'MOLECULE_IT_PLATFORM') }}_repo_{{ lookup('env', 'BRANCH_NAME') }}_{{ lookup('env', 'BUILD_NUMBER') }}
-      register: molecule_ec2
-
     - name: Destroy Shared contentstore
       community.aws.efs:
         state: absent


### PR DESCRIPTION
OPSEXP-1328

not sure if there is a way to just skip the cleanup phase that make sense only when running molecule locally (not on CI where the local environment is going to be discarded immediately after)