### PR TITLE
Fixing alfresco user for T-Router service

### DIFF
--- a/roles/trouter/templates/alfresco-transform-router.service
+++ b/roles/trouter/templates/alfresco-transform-router.service
@@ -4,7 +4,7 @@ After=syslog.socket network.target
 
 [Service]
 Type=simple
-User=alfresco
+User={{ username }}
 ExecStart={{ binaries_folder }}/ats-atr.sh
 
 [Install]


### PR DESCRIPTION
In case application user is different than Alfresco, T-Router service is not able to start. 
This fix uses the application user defined in `roles/common/vars/main.yml`

Fix #371 