### PR TITLE
OPSEXP-1620 Update ACS versions via updatecli

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,6 +1,6 @@
-# Developers' guide
+# Developers guide
 
-This page is a developer's guide to popular commands used in the process of setting up environment and testing.
+This page is a developers guide for to popular commands used in the process of setting up environment for development and testing.
 
 ## Basic pipenv knowledge
 
@@ -131,3 +131,21 @@ and possibly added in separate task files.
 
 The OS support table in `docs/README.md` must be updates and so does the
 `supported_os` variable in the `group_vars/all.yml` file.
+
+### Bumping ACS version via updatecli
+
+This repo provide experimental support for keeping ACS components versions
+defined in `groups_vars/all.yml` in sync the the ACS releases.
+
+The `updatecli_config.yml` file provides the main pipeline definition and there
+are multiple values files depending on which acs major version we want to check
+for any new minor release.
+
+Run updatecli with:
+
+```bash
+updatecli apply --config scripts/updatecli/updatecli_config.yml --values scripts/updatecli/updatecli_acs73.yml
+```
+
+When the command completes succesfully you will find the `groups_vars/all.yml`
+automatically modified with the latest available versions as requested.

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -2,31 +2,31 @@ acs:
   version: "7.2"
 
 adw:
-  version: "~3.0"
+  version: "3.0"
 
 aos:
-  version: "~1.4"
+  version: "1.4"
 
 apiExplorer:
-  version: "~7.2"
+  version: "7.2"
 
 dsync:
-  version: "~3.7"
+  version: "3.7"
 
 googleDrive:
-  version: "~3.2"
+  version: "3.2"
 
 search:
-  version: "~2.0"
+  version: "2.0"
 
 searchEnterprise:
-  version: "~3.1"
+  version: "3.1"
 
 transform:
-  version: "~2"
+  version: "2"
 
 trouter:
-  version: "~1"
+  version: "1"
 
 target_file: group_vars/all.yml
 acs_version_pattern: '(-M\d*)?$'

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -1,33 +1,31 @@
 acs:
-  version: "7.2"
+  version: "~7.2"
 
 adw:
-  version: "2.9"
+  version: "~3.0"
 
 aos:
-  version: "1.4"
+  version: "~1.4"
 
 apiExplorer:
-  version: "7.2"
+  version: "~7.2"
 
 dsync:
-  version: "3.6"
+  version: "~3.7"
 
 googleDrive:
-  version: "3.2"
+  version: "~3.2"
 
 search:
-  version: "2.0"
+  version: "~2.0"
 
 searchEnterprise:
-  version: "3.1"
+  version: "~3.1"
 
 transform:
-  version: "2.5"
+  version: "~2"
 
 trouter:
-  version: "1.5"
-
-version_pattern: '(-M\d*)?$'
+  version: "~1"
 
 target_file: group_vars/all.yml

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -1,0 +1,14 @@
+acs:
+  version: 7.2
+
+search:
+  version: 2.0
+
+transform:
+  version: 2.5
+
+trouter:
+  version: 1.5
+
+dsync:
+  version: 3.6

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -4,8 +4,17 @@ acs:
 adw:
   version: "2.9"
 
+aos:
+  version: "1.4"
+
 apiExplorer:
   version: "7.2"
+
+dsync:
+  version: "3.6"
+
+googleDrive:
+  version: "3.2"
 
 search:
   version: "2.0"
@@ -18,8 +27,5 @@ transform:
 
 trouter:
   version: "1.5"
-
-dsync:
-  version: "3.6"
 
 version_pattern: '(-M\d*)?$'

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -1,6 +1,9 @@
 acs:
   version: "7.2"
 
+adw:
+  version: "2.9"
+
 apiExplorer:
   version: "7.2"
 

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -29,3 +29,5 @@ trouter:
   version: "1.5"
 
 version_pattern: '(-M\d*)?$'
+
+target_file: group_vars/all.yml

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -1,14 +1,20 @@
 acs:
-  version: 7.2
+  version: "7.2"
+
+apiExplorer:
+  version: "7.2"
 
 search:
-  version: 2.0
+  version: "2.0"
+
+searchEnterprise:
+  version: "3.1"
 
 transform:
-  version: 2.5
+  version: "2.5"
 
 trouter:
-  version: 1.5
+  version: "1.5"
 
 dsync:
-  version: 3.6
+  version: "3.6"

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -1,5 +1,5 @@
 acs:
-  version: "~7.2"
+  version: "7.2"
 
 adw:
   version: "~3.0"
@@ -29,3 +29,4 @@ trouter:
   version: "~1"
 
 target_file: group_vars/all.yml
+acs_version_pattern: '(-M\d*)?$'

--- a/scripts/updatecli/updatecli_acs72.yml
+++ b/scripts/updatecli/updatecli_acs72.yml
@@ -18,3 +18,5 @@ trouter:
 
 dsync:
   version: "3.6"
+
+version_pattern: '(-M\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -1,33 +1,31 @@
 acs:
-  version: "7.3"
+  version: "~7.3"
 
 adw:
-  version: "3.1"
+  version: "~3.1"
 
 aos:
-  version: "1.5"
+  version: "~1.5"
 
 apiExplorer:
-  version: "7.3"
+  version: "~7.3"
 
 dsync:
-  version: "3.8"
+  version: "~3.8"
 
 googleDrive:
-  version: "3.3"
+  version: "~3.3"
 
 search:
-  version: "2.0"
+  version: "~2.0"
 
 searchEnterprise:
-  version: "3.2"
+  version: "~3.2"
 
 transform:
-  version: "3.0"
+  version: "~3"
 
 trouter:
-  version: "2.0"
-
-version_pattern: '(-(A|M)\d*)?$'
+  version: "~2"
 
 target_file: group_vars/all.yml

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -29,4 +29,4 @@ trouter:
   version: "2"
 
 target_file: group_vars/all.yml
-version_pattern: '(-(A|M)\d*)?$'
+version_pattern: '(-M\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -4,8 +4,17 @@ acs:
 adw:
   version: "3.1"
 
+aos:
+  version: "1.5"
+
 apiExplorer:
   version: "7.3"
+
+dsync:
+  version: "3.8"
+
+googleDrive:
+  version: "3.3"
 
 search:
   version: "2.0"
@@ -18,8 +27,5 @@ transform:
 
 trouter:
   version: "2.0"
-
-dsync:
-  version: "3.8"
 
 version_pattern: '(-(A|M)\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -1,5 +1,5 @@
 acs:
-  version: "~7.3"
+  version: "7.3"
 
 adw:
   version: "~3.1"
@@ -29,3 +29,4 @@ trouter:
   version: "~2"
 
 target_file: group_vars/all.yml
+acs_version_pattern: '(-(A|M)\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -7,6 +7,9 @@ apiExplorer:
 search:
   version: "2.0"
 
+searchEnterprise:
+  version: "3.2"
+
 transform:
   version: "2.5"
 

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -17,6 +17,6 @@ trouter:
   version: "2.0"
 
 dsync:
-  version: "4.0"
+  version: "3.8"
 
 version_pattern: '(-(A|M)\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -2,31 +2,31 @@ acs:
   version: "7.3"
 
 adw:
-  version: "~3.1"
+  version: "3.1"
 
 aos:
-  version: "~1.5"
+  version: "1.5"
 
 apiExplorer:
-  version: "~7.3"
+  version: "7.3"
 
 dsync:
-  version: "~3.8"
+  version: "3.8"
 
 googleDrive:
-  version: "~3.3"
+  version: "3.3"
 
 search:
-  version: "~2.0"
+  version: "2.0"
 
 searchEnterprise:
-  version: "~3.2"
+  version: "3.2"
 
 transform:
-  version: "~3"
+  version: "3"
 
 trouter:
-  version: "~2"
+  version: "2"
 
 target_file: group_vars/all.yml
-acs_version_pattern: '(-(A|M)\d*)?$'
+version_pattern: '(-(A|M)\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -1,0 +1,17 @@
+acs:
+  version: "7.3"
+
+apiExplorer:
+  version: "7.2"
+
+search:
+  version: "2.0"
+
+transform:
+  version: "2.5"
+
+trouter:
+  version: "1.5"
+
+dsync:
+  version: "4.0"

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -2,7 +2,7 @@ acs:
   version: "7.3"
 
 apiExplorer:
-  version: "7.2"
+  version: "7.3"
 
 search:
   version: "2.0"
@@ -11,10 +11,12 @@ searchEnterprise:
   version: "3.2"
 
 transform:
-  version: "2.5"
+  version: "3.0"
 
 trouter:
-  version: "1.5"
+  version: "2.0"
 
 dsync:
   version: "4.0"
+
+version_pattern: '(-(A|M)\d*)?$'

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -1,6 +1,9 @@
 acs:
   version: "7.3"
 
+adw:
+  version: "3.1"
+
 apiExplorer:
   version: "7.3"
 

--- a/scripts/updatecli/updatecli_acs73.yml
+++ b/scripts/updatecli/updatecli_acs73.yml
@@ -29,3 +29,5 @@ trouter:
   version: "2.0"
 
 version_pattern: '(-(A|M)\d*)?$'
+
+target_file: group_vars/all.yml

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -78,15 +78,23 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .adw.version }}.(\d+){{ .version_pattern }}'
+        pattern: '^{{ .adw.version }}.(\d+){{ .version_pattern }}'
   aosAmp:
     name: AOS AMP
     kind: gittag
     scmid: aosAmpRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .aos.version }}.(\d+){{ .version_pattern }}'
   googleDriveAmp:
     name: Google Drive AMP
     kind: gittag
     scmid: googleDriveAmpRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .googleDrive.version }}.(\d+){{ .version_pattern }}'
   apiExplorer:
     name: Api explorer {{ .apiExplorer.version }}.x
     kind: gittag

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -64,7 +64,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .acs.version }}.(\d+)(-M\d*)?$'
+        pattern: '{{ .acs.version }}.(\d+){{ .version_pattern }}'
   aosAmp:
     name: AOS AMP
     kind: gittag
@@ -74,13 +74,13 @@ sources:
     kind: gittag
     scmid: googleDriveAmpRepo
   apiExplorer:
-    name: Api explorer {{ .acs.version }}.x
+    name: Api explorer {{ .apiExplorer.version }}.x
     kind: gittag
     scmid: apiExplorerRepo
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ if .apiExplorer.version }}{{ .apiExplorer.version }}{{ else }}{{ .acs.version }}{{ end }}.(\d+)$'
+        pattern: '{{ .apiExplorer.version }}.(\d+){{ .version_pattern }}'
   dsync:
     name: Desktop Sync {{ .dsync.version }}
     kind: gittag
@@ -88,7 +88,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .dsync.version }}.(\d+)(-M\d*)?$'
+        pattern: '{{ .dsync.version }}.(\d+){{ .version_pattern }}'
   search:
     name: InsightEngine {{ .search.version }}.x
     kind: gittag
@@ -96,7 +96,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: "{{ .search.version }}.*"
+        pattern: '{{ .search.version }}.(\d+){{ .version_pattern }}'
   searchEnterprise:
     name: Search Enterprise {{ .searchEnterprise.version }}.x
     kind: gittag
@@ -104,7 +104,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .searchEnterprise.version }}.(\d+)(-M\d*)?$'
+        pattern: '{{ .searchEnterprise.version }}.(\d+){{ .version_pattern }}'
   transform:
     name: Transform Core {{ .transform.version }}.x
     kind: gittag
@@ -112,7 +112,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .transform.version }}.(\d+)$'
+        pattern: '{{ .transform.version }}.(\d+){{ .version_pattern }}'
   trouter:
     name: ATS Transform Service {{ .trouter.version }}.x
     kind: gittag
@@ -120,7 +120,7 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .trouter.version }}.(\d+)$'
+        pattern: '{{ .trouter.version }}.(\d+){{ .version_pattern }}'
   # adw:
   #   name: adw
   #   kind: maven

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -1,5 +1,4 @@
-# manifest.yaml
-title: ACS update example
+title: ACS update pipeline
 
 scms:
   acsRepo:
@@ -38,6 +37,12 @@ scms:
       url: git@github.com:Alfresco/InsightEngine.git
       branch: master
       directory: '/tmp/updatecli/search'
+  searchEnterpriseRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/alfresco-elasticsearch-connector.git
+      branch: master
+      directory: '/tmp/updatecli/search_enterprise'
   transformRepo:
     kind: git
     spec:
@@ -92,6 +97,14 @@ sources:
       versionFilter:
         kind: regex
         pattern: "{{ .search.version }}.*"
+  searchEnterprise:
+    name: Search Enterprise {{ .searchEnterprise.version }}.x
+    kind: gittag
+    scmid: searchEnterpriseRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .searchEnterprise.version }}.(\d+)(-M\d*)?$'
   transform:
     name: Transform Core {{ .transform.version }}.x
     kind: gittag
@@ -174,6 +187,13 @@ targets:
     sourceid: search
     spec:
       key: search.version
+      file: group_vars/all.yml
+  searchEnterprise:
+    name: Bump Search Enterprise
+    kind: yaml
+    sourceid: searchEnterprise
+    spec:
+      key: search_enterprise.version
       file: group_vars/all.yml
   transform:
     name: Bump Transform Core

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -62,88 +62,89 @@ scms:
       branch: master
       directory: '/tmp/updatecli/trouter'
 
+# Alfresco follow semantic versioning (https://semver.org/)
+# Available selectors: https://github.com/Masterminds/semver#basic-comparisons
 sources:
   acs:
-    name: ACS {{ .acs.version }}.x
+    name: ACS {{ .acs.version }}
     kind: gittag
     scmid: acsRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .acs.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .acs.version }}'
   adw:
-    name: ADW {{ .adw.version }}.x
+    name: ADW {{ .adw.version }}
     kind: gittag
     scmid: adwRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '^{{ .adw.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .adw.version }}'
   aosAmp:
-    name: AOS AMP
+    name: AOS AMP {{ .aos.version }}
     kind: gittag
     scmid: aosAmpRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .aos.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .aos.version }}'
   googleDriveAmp:
-    name: Google Drive AMP
+    name: Google Drive AMP {{ .googleDrive.version }}
     kind: gittag
     scmid: googleDriveAmpRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .googleDrive.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .googleDrive.version }}'
   apiExplorer:
-    name: Api explorer {{ .apiExplorer.version }}.x
+    name: Api explorer {{ .apiExplorer.version }}
     kind: gittag
     scmid: apiExplorerRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .apiExplorer.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .apiExplorer.version }}'
   dsync:
     name: Desktop Sync {{ .dsync.version }}
     kind: gittag
     scmid: dsyncRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .dsync.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .dsync.version }}'
   search:
-    name: InsightEngine {{ .search.version }}.x
+    name: InsightEngine {{ .search.version }}
     kind: gittag
     scmid: searchRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .search.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .search.version }}'
   searchEnterprise:
-    name: Search Enterprise {{ .searchEnterprise.version }}.x
+    name: Search Enterprise {{ .searchEnterprise.version }}
     kind: gittag
     scmid: searchEnterpriseRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .searchEnterprise.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .searchEnterprise.version }}'
   transform:
-    name: Transform Core {{ .transform.version }}.x
+    name: Transform Core {{ .transform.version }}
     kind: gittag
     scmid: transformRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .transform.version }}.(\d+){{ .version_pattern }}'
+        kind: semver
+        pattern: '{{ .transform.version }}'
   trouter:
-    name: ATS Transform Service {{ .trouter.version }}.x
+    name: ATS Transform Service {{ .trouter.version }}
     kind: gittag
     scmid: trouterRepo
     spec:
       versionFilter:
-        kind: regex
-        pattern: '{{ .trouter.version }}.(\d+){{ .version_pattern }}'
-
+        kind: semver
+        pattern: '{{ .trouter.version }}'
 
 targets:
   acs:

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -66,13 +66,13 @@ scms:
 # Available selectors: https://github.com/Masterminds/semver#basic-comparisons
 sources:
   acs:
-    name: ACS {{ .acs.version }}
+    name: ACS {{ .acs.version }}.x
     kind: gittag
     scmid: acsRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .acs.version }}'
+        kind: regex
+        pattern: '{{ .acs.version }}.(\d+){{ .acs_version_pattern }}'
   adw:
     name: ADW {{ .adw.version }}
     kind: gittag

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -72,79 +72,79 @@ sources:
     spec:
       versionFilter:
         kind: regex
-        pattern: '{{ .acs.version }}.(\d+){{ .acs_version_pattern }}'
+        pattern: '{{ .acs.version }}(.(\d+))+{{ .version_pattern }}'
   adw:
     name: ADW {{ .adw.version }}
     kind: gittag
     scmid: adwRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .adw.version }}'
+        kind: regex
+        pattern: '{{ .adw.version }}(.(\d+))+{{ .version_pattern }}'
   aosAmp:
     name: AOS AMP {{ .aos.version }}
     kind: gittag
     scmid: aosAmpRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .aos.version }}'
+        kind: regex
+        pattern: '{{ .aos.version }}(.(\d+))+{{ .version_pattern }}'
   googleDriveAmp:
     name: Google Drive AMP {{ .googleDrive.version }}
     kind: gittag
     scmid: googleDriveAmpRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .googleDrive.version }}'
+        kind: regex
+        pattern: '{{ .googleDrive.version }}(.(\d+))+{{ .version_pattern }}'
   apiExplorer:
     name: Api explorer {{ .apiExplorer.version }}
     kind: gittag
     scmid: apiExplorerRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .apiExplorer.version }}'
+        kind: regex
+        pattern: '{{ .apiExplorer.version }}(.(\d+))+{{ .version_pattern }}'
   dsync:
     name: Desktop Sync {{ .dsync.version }}
     kind: gittag
     scmid: dsyncRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .dsync.version }}'
+        kind: regex
+        pattern: '{{ .dsync.version }}(.(\d+))+{{ .version_pattern }}'
   search:
     name: InsightEngine {{ .search.version }}
     kind: gittag
     scmid: searchRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .search.version }}'
+        kind: regex
+        pattern: '{{ .search.version }}(.(\d+))+{{ .version_pattern }}'
   searchEnterprise:
     name: Search Enterprise {{ .searchEnterprise.version }}
     kind: gittag
     scmid: searchEnterpriseRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .searchEnterprise.version }}'
+        kind: regex
+        pattern: '{{ .searchEnterprise.version }}(.(\d+))+{{ .version_pattern }}'
   transform:
     name: Transform Core {{ .transform.version }}
     kind: gittag
     scmid: transformRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .transform.version }}'
+        kind: regex
+        pattern: '{{ .transform.version }}(.(\d+))+{{ .version_pattern }}'
   trouter:
     name: ATS Transform Service {{ .trouter.version }}
     kind: gittag
     scmid: trouterRepo
     spec:
       versionFilter:
-        kind: semver
-        pattern: '{{ .trouter.version }}'
+        kind: regex
+        pattern: '{{ .trouter.version }}(.(\d+))+{{ .version_pattern }}'
 
 targets:
   acs:

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -153,88 +153,88 @@ targets:
     sourceid: acs
     spec:
       key: acs.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   adw:
     name: Bump adw
     kind: yaml
     sourceid: adw
     spec:
       key: adw.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   aosAmp:
     name: Bump AOS AMP
     kind: yaml
     sourceid: aosAmp
     spec:
       key: amps.aos_module.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   dsyncAmp:
     name: Bump Device Sync AMP
     kind: yaml
     sourceid: dsync
     spec:
       key: amps.device_sync.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   googleDriveRepoAmp:
     name: Bump Google Drive Repo AMP
     kind: yaml
     sourceid: googleDriveAmp
     spec:
       key: amps.googledrive_repo.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   googleDriveShareAmp:
     name: Bump Google Drive Share AMP
     kind: yaml
     sourceid: googleDriveAmp
     spec:
       key: amps.googledrive_share.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   apiExplorer:
     name: Bump api-explorer
     kind: yaml
     sourceid: apiExplorer
     spec:
       key: api_explorer.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   dsync:
     name: Bump sync
     kind: yaml
     sourceid: dsync
     spec:
       key: sync.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   search:
     name: Bump InsightEngine
     kind: yaml
     sourceid: search
     spec:
       key: search.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   searchEnterprise:
     name: Bump Search Enterprise
     kind: yaml
     sourceid: searchEnterprise
     spec:
       key: search_enterprise.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   transform:
     name: Bump Transform Core
     kind: yaml
     sourceid: transform
     spec:
       key: transform.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   trouter:
     name: Bump ATS Transform Service
     kind: yaml
     sourceid: trouter
     spec:
       key: trouter.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'
   sfs:
     name: Bump Shared File Store
     kind: yaml
     sourceid: trouter
     spec:
       key: sfs.version
-      file: {{ .target_file }}
+      file: '{{ .target_file }}'

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -152,88 +152,88 @@ targets:
     sourceid: acs
     spec:
       key: acs.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   adw:
     name: Bump adw
     kind: yaml
     sourceid: adw
     spec:
       key: adw.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   aosAmp:
     name: Bump AOS AMP
     kind: yaml
     sourceid: aosAmp
     spec:
       key: amps.aos_module.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   dsyncAmp:
     name: Bump Device Sync AMP
     kind: yaml
     sourceid: dsync
     spec:
       key: amps.device_sync.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   googleDriveRepoAmp:
     name: Bump Google Drive Repo AMP
     kind: yaml
     sourceid: googleDriveAmp
     spec:
       key: amps.googledrive_repo.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   googleDriveShareAmp:
     name: Bump Google Drive Share AMP
     kind: yaml
     sourceid: googleDriveAmp
     spec:
       key: amps.googledrive_share.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   apiExplorer:
     name: Bump api-explorer
     kind: yaml
     sourceid: apiExplorer
     spec:
       key: api_explorer.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   dsync:
     name: Bump sync
     kind: yaml
     sourceid: dsync
     spec:
       key: sync.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   search:
     name: Bump InsightEngine
     kind: yaml
     sourceid: search
     spec:
       key: search.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   searchEnterprise:
     name: Bump Search Enterprise
     kind: yaml
     sourceid: searchEnterprise
     spec:
       key: search_enterprise.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   transform:
     name: Bump Transform Core
     kind: yaml
     sourceid: transform
     spec:
       key: transform.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   trouter:
     name: Bump ATS Transform Service
     kind: yaml
     sourceid: trouter
     spec:
       key: trouter.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}
   sfs:
     name: Bump Shared File Store
     kind: yaml
     sourceid: trouter
     spec:
       key: sfs.version
-      file: group_vars/all.yml
+      file: {{ .target_file }}

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -7,6 +7,12 @@ scms:
         url: https://github.com/Alfresco/acs-packaging.git
         branch: master
         directory: '/tmp/updatecli/acs'
+  adwRepo:
+    kind: git
+    spec:
+        url: https://github.com/Alfresco/alfresco-content-app.git
+        branch: master
+        directory: '/tmp/updatecli/adw'
   aosAmpRepo:
     kind: git
     spec:
@@ -65,6 +71,14 @@ sources:
       versionFilter:
         kind: regex
         pattern: '{{ .acs.version }}.(\d+){{ .version_pattern }}'
+  adw:
+    name: ADW {{ .adw.version }}.x
+    kind: gittag
+    scmid: adwRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .adw.version }}.(\d+){{ .version_pattern }}'
   aosAmp:
     name: AOS AMP
     kind: gittag
@@ -121,14 +135,6 @@ sources:
       versionFilter:
         kind: regex
         pattern: '{{ .trouter.version }}.(\d+){{ .version_pattern }}'
-  # adw:
-  #   name: adw
-  #   kind: maven
-  #   spec:
-  #     url: '{{ requiredEnv "NEXUS_USERNAME" }}:{{ requiredEnv "NEXUS_PASSWORD" }}@nexus.alfresco.com/nexus/content/repositories'
-  #     repository: enterprise-releases
-  #     groupID: org.alfresco
-  #     artifactID:  alfresco-digital-workspace
 
 
 targets:
@@ -138,6 +144,13 @@ targets:
     sourceid: acs
     spec:
       key: acs.version
+      file: group_vars/all.yml
+  adw:
+    name: Bump adw
+    kind: yaml
+    sourceid: adw
+    spec:
+      key: adw.version
       file: group_vars/all.yml
   aosAmp:
     name: Bump AOS AMP
@@ -216,10 +229,3 @@ targets:
     spec:
       key: sfs.version
       file: group_vars/all.yml
-  # adw:
-  #   name: Bump adw
-  #   kind: yaml
-  #   sourceid: adw
-  #   spec:
-  #     key: adw.version
-  #     file: group_vars/all.yml

--- a/scripts/updatecli/updatecli_config.yml
+++ b/scripts/updatecli/updatecli_config.yml
@@ -1,0 +1,205 @@
+# manifest.yaml
+title: ACS update example
+
+scms:
+  acsRepo:
+    kind: git
+    spec:
+        url: https://github.com/Alfresco/acs-packaging.git
+        branch: master
+        directory: '/tmp/updatecli/acs'
+  aosAmpRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/alfresco-aos-module.git
+      branch: master
+      directory: '/tmp/updatecli/aos-amp'
+  googleDriveAmpRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/googledrive.git
+      branch: master
+      directory: '/tmp/updatecli/googledrive'
+  apiExplorerRepo:
+    kind: git
+    spec:
+        url: https://github.com/Alfresco/rest-api-explorer.git
+        branch: master
+        directory: '/tmp/updatecli/api-explorer'
+  dsyncRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/dsync-services.git
+      branch: master
+      directory: '/tmp/updatecli/dsync'
+  searchRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/InsightEngine.git
+      branch: master
+      directory: '/tmp/updatecli/search'
+  transformRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/alfresco-transform-core.git
+      branch: master
+      directory: '/tmp/updatecli/transform'
+  trouterRepo:
+    kind: git
+    spec:
+      url: git@github.com:Alfresco/alfresco-transform-service.git
+      branch: master
+      directory: '/tmp/updatecli/trouter'
+
+sources:
+  acs:
+    name: ACS {{ .acs.version }}.x
+    kind: gittag
+    scmid: acsRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .acs.version }}.(\d+)(-M\d*)?$'
+  aosAmp:
+    name: AOS AMP
+    kind: gittag
+    scmid: aosAmpRepo
+  googleDriveAmp:
+    name: Google Drive AMP
+    kind: gittag
+    scmid: googleDriveAmpRepo
+  apiExplorer:
+    name: Api explorer {{ .acs.version }}.x
+    kind: gittag
+    scmid: apiExplorerRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ if .apiExplorer.version }}{{ .apiExplorer.version }}{{ else }}{{ .acs.version }}{{ end }}.(\d+)$'
+  dsync:
+    name: Desktop Sync {{ .dsync.version }}
+    kind: gittag
+    scmid: dsyncRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .dsync.version }}.(\d+)(-M\d*)?$'
+  search:
+    name: InsightEngine {{ .search.version }}.x
+    kind: gittag
+    scmid: searchRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: "{{ .search.version }}.*"
+  transform:
+    name: Transform Core {{ .transform.version }}.x
+    kind: gittag
+    scmid: transformRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .transform.version }}.(\d+)$'
+  trouter:
+    name: ATS Transform Service {{ .trouter.version }}.x
+    kind: gittag
+    scmid: trouterRepo
+    spec:
+      versionFilter:
+        kind: regex
+        pattern: '{{ .trouter.version }}.(\d+)$'
+  # adw:
+  #   name: adw
+  #   kind: maven
+  #   spec:
+  #     url: '{{ requiredEnv "NEXUS_USERNAME" }}:{{ requiredEnv "NEXUS_PASSWORD" }}@nexus.alfresco.com/nexus/content/repositories'
+  #     repository: enterprise-releases
+  #     groupID: org.alfresco
+  #     artifactID:  alfresco-digital-workspace
+
+
+targets:
+  acs:
+    name: Bump acs
+    kind: yaml
+    sourceid: acs
+    spec:
+      key: acs.version
+      file: group_vars/all.yml
+  aosAmp:
+    name: Bump AOS AMP
+    kind: yaml
+    sourceid: aosAmp
+    spec:
+      key: amps.aos_module.version
+      file: group_vars/all.yml
+  dsyncAmp:
+    name: Bump Device Sync AMP
+    kind: yaml
+    sourceid: dsync
+    spec:
+      key: amps.device_sync.version
+      file: group_vars/all.yml
+  googleDriveRepoAmp:
+    name: Bump Google Drive Repo AMP
+    kind: yaml
+    sourceid: googleDriveAmp
+    spec:
+      key: amps.googledrive_repo.version
+      file: group_vars/all.yml
+  googleDriveShareAmp:
+    name: Bump Google Drive Share AMP
+    kind: yaml
+    sourceid: googleDriveAmp
+    spec:
+      key: amps.googledrive_share.version
+      file: group_vars/all.yml
+  apiExplorer:
+    name: Bump api-explorer
+    kind: yaml
+    sourceid: apiExplorer
+    spec:
+      key: api_explorer.version
+      file: group_vars/all.yml
+  dsync:
+    name: Bump sync
+    kind: yaml
+    sourceid: dsync
+    spec:
+      key: sync.version
+      file: group_vars/all.yml
+  search:
+    name: Bump InsightEngine
+    kind: yaml
+    sourceid: search
+    spec:
+      key: search.version
+      file: group_vars/all.yml
+  transform:
+    name: Bump Transform Core
+    kind: yaml
+    sourceid: transform
+    spec:
+      key: transform.version
+      file: group_vars/all.yml
+  trouter:
+    name: Bump ATS Transform Service
+    kind: yaml
+    sourceid: trouter
+    spec:
+      key: trouter.version
+      file: group_vars/all.yml
+  sfs:
+    name: Bump Shared File Store
+    kind: yaml
+    sourceid: trouter
+    spec:
+      key: sfs.version
+      file: group_vars/all.yml
+  # adw:
+  #   name: Bump adw
+  #   kind: yaml
+  #   sourceid: adw
+  #   spec:
+  #     key: adw.version
+  #     file: group_vars/all.yml


### PR DESCRIPTION
https://www.updatecli.io/docs/prologue/introduction/

OPSEXP-1620

update group_vars/all.yml versions with:

```
updatecli apply --config scripts/updatecli/updatecli_config.yml --values scripts/updatecli/updatecli_acs73.yml
```

- support the versions specified in molecule tests