### PR TITLE
OPSEXP-1629 Bump versions for ACS 7.2.1

### DIFF
--- a/community-extra-vars.yml
+++ b/community-extra-vars.yml
@@ -1,6 +1,6 @@
 ---
 acs:
-  version: 7.2.0
+  version: 7.2.1
   edition: Community
 
 downloads:

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,7 +14,7 @@ nexus_repository:
   enterprise_releases: "{{ artifacts_repositories.enterprise.base_url }}/{{ artifacts_repositories.enterprise.repository }}/{{ artifacts_repositories.enterprise.group_id }}"
 
 acs:
-  version: 7.2.0
+  version: 7.2.1
   edition: Enterprise
 
 amps:
@@ -23,25 +23,20 @@ amps:
   device_sync:
     version: 3.6.0
   googledrive_repo:
-    version: 3.2.1
+    version: 3.2.2
   googledrive_share:
-    version: 3.2.1
-
+    version: 3.2.2
 api_explorer:
-  version: 7.2.0
-
+  version: 7.2.1
 search:
-  version: 2.0.3
-
+  version: 2.0.4
 transform:
   version: 2.5.7
 
 trouter:
-  version: 1.5.2
-
+  version: 1.5.3
 sfs:
-  version: 0.16.1
-
+  version: 1.5.3
 adw:
   version: 2.7.0
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,7 +38,7 @@ trouter:
 sfs:
   version: 1.5.3
 adw:
-  version: 2.7.0
+  version: 2.9.0
 
 sync:
   version: 3.6.0

--- a/tests/test-config-community.json
+++ b/tests/test-config-community.json
@@ -7,12 +7,12 @@
     "assertions": {
       "acs": {
         "edition": "Community",
-        "version": "7.2.0",
+        "version": "7.2.1",
         "identity": false,
         "modules": [
           {
             "id": "org.alfresco.integrations.google.docs",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "installed": true
           },
           {

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -7,12 +7,12 @@
     "assertions": {
       "acs": {
         "edition": "Enterprise",
-        "version": "7.2.0",
+        "version": "7.2.1",
         "identity": false,
         "modules": [
           {
             "id": "org.alfresco.integrations.google.docs",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "installed": true
           },
           {
@@ -28,7 +28,7 @@
         ]
       },
       "adw": {
-        "version": "2.7.0"
+        "version": "2.9.0"
       }
     }
   }

--- a/tests/test-extra-vars.yml
+++ b/tests/test-extra-vars.yml
@@ -4,9 +4,9 @@ amps:
   device_sync:
     version: 3.6.0
   googledrive_repo:
-    version: 3.2.1
+    version: 3.2.2
   googledrive_share:
-    version: 3.2.1
+    version: 3.2.2
   ags_repo:
     version: 3.5.0
   ags_share:


### PR DESCRIPTION
OPSEXP-1629

generated via https://github.com/Alfresco/alfresco-ansible-deployment/pull/387