### PR TITLE
OPSEXP-1762 Fix flaky elasticsearch integration tests

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -105,9 +105,7 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.nexus_username }}
           NEXUS_PASSWORD: ${{ secrets.nexus_password }}
           CLONE_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-        run: |
-          pipenv run molecule converge -s ${{ matrix.scenario.name }} &&
-          pipenv run molecule verify -s ${{ matrix.scenario.name }}
+        run: pipenv run molecule test -s ${{ matrix.scenario.name }}
 
   ec2:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -104,7 +104,9 @@ jobs:
           NEXUS_USERNAME: ${{ secrets.nexus_username }}
           NEXUS_PASSWORD: ${{ secrets.nexus_password }}
           CLONE_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
-        run: pipenv run molecule test -s ${{ matrix.scenario.name }}
+        run: |
+          pipenv run molecule converge -s ${{ matrix.scenario.name }} &&
+          pipenv run molecule verify -s ${{ matrix.scenario.name }}
 
       - name: Debug on failure
         if: failure()

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -66,7 +66,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         molecule_distro:
           - image: centos:7
@@ -105,6 +105,14 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.nexus_password }}
           CLONE_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         run: pipenv run molecule test -s ${{ matrix.scenario.name }}
+
+      - name: Debug on failure
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
+        with:
+          # provide access to SSH user that triggered the build
+          limit-access-to-actor: true
 
   ec2:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -2,7 +2,6 @@ name: "enterprise"
 
 on:
   push:
-    branches: ["*"]
     paths-ignore:
       - 'docs/**'
       - '*.md'
@@ -108,14 +107,6 @@ jobs:
           pipenv run molecule converge -s ${{ matrix.scenario.name }} &&
           pipenv run molecule verify -s ${{ matrix.scenario.name }}
 
-      - name: Debug on failure
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 60
-        with:
-          # provide access to SSH user that triggered the build
-          limit-access-to-actor: true
-
   ec2:
     if: github.actor != 'dependabot[bot]'
     needs:
@@ -174,8 +165,6 @@ jobs:
         uses: ./.github/actions/galaxy
         with:
           cache-name: enterprise
-
-      - run: ansible-galaxy install -r requirements.yml
 
       # https://stackoverflow.com/a/64210623/547195
       - name: Get branch name

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -63,6 +63,8 @@ jobs:
 
   docker_integration:
     if: github.actor != 'dependabot[bot]'
+    needs:
+      - docker
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -111,7 +113,6 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     needs:
       - docker
-      - docker_integration
     name: ${{ matrix.molecule_scenario.desc }}
     runs-on: ubuntu-latest
     strategy:

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -49,6 +49,15 @@
   tags:
     - activemq
 
+- name: Elasticsearch Role
+  hosts: elasticsearch
+  gather_facts: no
+  roles:
+    - role: "../roles/elasticsearch"
+      when: acs.edition == "Enterprise"
+  tags:
+    - elasticsearch
+
 - name: Transformers Role
   hosts: transformers
   gather_facts: no
@@ -157,15 +166,6 @@
         marker_end: SFS_END
   tags:
     - sfs
-
-- name: Elasticsearch Role
-  hosts: elasticsearch
-  gather_facts: no
-  roles:
-    - role: "../roles/elasticsearch"
-      when: acs.edition == "Enterprise"
-  tags:
-    - elasticsearch
 
 - name: Enterprise Search Role
   hosts: search_enterprise

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -74,3 +74,5 @@ keystore_src: >-
   {%- else -%}
     {{ content_folder }}/alf_data/keystore/
   {%- endif %}
+
+repository_monitored_startup_timeout_seconds: 300

--- a/roles/repository/templates/alfresco-content-monitored-startup.service.j2
+++ b/roles/repository/templates/alfresco-content-monitored-startup.service.j2
@@ -7,5 +7,5 @@ BindsTo=alfresco-content.service
 Type=notify
 NotifyAccess=exec
 ExecStart={{ binaries_folder }}/alfresco-content-monitored-startup.sh
-TimeoutStartSec=300
+TimeoutStartSec={{ repository_monitored_startup_timeout_seconds }}
 Environment=SVC=alfresco-content-probes

--- a/roles/sync/handlers/main.yml
+++ b/roles/sync/handlers/main.yml
@@ -1,13 +1,5 @@
 ---
-# handlers file for trouter
-- name: wait-for-repo
-  uri:
-    url: "http://{{ repo_host }}:{{ ports_cfg.repository.http }}/alfresco/api/-default-/public/alfresco/versions/1/probes/-ready-"
-  register: result
-  until: result.status == 200
-  retries: 12
-  delay: 10
-
+# handlers file for sync
 - name: enable-sync
   become: true
   service:

--- a/roles/sync/handlers/main.yml
+++ b/roles/sync/handlers/main.yml
@@ -1,9 +1,12 @@
 ---
 # handlers file for trouter
 - name: wait-for-repo
-  wait_for:
-    host: "{{ nginx_host }}"
-    port: "{{ ports_cfg.nginx.http }}"
+  uri:
+    url: "http://{{ repo_host }}:{{ ports_cfg.repository.http }}/alfresco/api/-default-/public/alfresco/versions/1/probes/-ready-"
+  register: result
+  until: result.status == 200
+  retries: 12
+  delay: 10
 
 - name: enable-sync
   become: true
@@ -26,5 +29,5 @@
     url: "http://127.0.0.1:{{ ports_cfg.sync.http }}/alfresco/healthcheck"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 12
   delay: 10

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -76,7 +76,6 @@
         mode: 'u=rwx,g=rwx'
         force: yes
       notify:
-        - wait-for-repo
         - restart-sync
 
     - name: Add paths to setenv file
@@ -98,7 +97,6 @@
         group: "{{ group_name }}"
         mode: 'u=rwx,g=rwx'
       notify:
-        - wait-for-repo
         - restart-sync
 
     - name: Add alfresco-sync.service service
@@ -109,6 +107,5 @@
         group: "{{ group_name }}"
         mode: 'u=rwx,g=rwx'
       notify:
-      - wait-for-repo
       - enable-sync
       - restart-sync


### PR DESCRIPTION
* Disable fail fast so flaky things won't make all the remaining job canceled 
* Start docker IT after completing docker role tests to lower the overall build time (docker IT and EC2 IT are run in parallel)

OPSEXP-1762