### PR TITLE
OPSEXP-1742 Bump detect-secrets plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,15 +39,10 @@ repos:
       - id: ansible-lint
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.1.0
+    rev: v1.4.0
     hooks:
       - id: detect-secrets
-        name: detect generic secrets
-        args:
-          - --baseline
-          - .secrets.baseline
-          - --exclude-secrets
-          - (dummy|admin|mp6yc0UD9e|alfresco)
+        args: ["--baseline", ".secrets.baseline"]
 
   - repo: https://github.com/awslabs/git-secrets
     rev: b9e96b3

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,6 +109,12 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "(admin|mp6yc0UD9e|alfresco)"
+      ]
     }
   ],
   "results": {
@@ -152,16 +158,6 @@
         "is_secret": false
       }
     ],
-    "roles/repository/molecule/default/tests/test_repository.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "roles/repository/molecule/default/tests/test_repository.py",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 56,
-        "is_secret": false
-      }
-    ],
     "roles/repository/tasks/main.yml": [
       {
         "type": "Secret Keyword",
@@ -169,16 +165,6 @@
         "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
         "is_verified": false,
         "line_number": 70,
-        "is_secret": false
-      }
-    ],
-    "roles/repository/templates/custom-slingshot-application-context.xml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "roles/repository/templates/custom-slingshot-application-context.xml",
-        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
-        "is_verified": false,
-        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -242,32 +228,6 @@
         "is_secret": false
       }
     ],
-    "tests/molecule/secrets.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/molecule/secrets.yml",
-        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
-        "is_verified": false,
-        "line_number": 1,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/molecule/secrets.yml",
-        "hashed_secret": "c521bbd712f047dc265cd51ce7484d6848e4ad41",
-        "is_verified": false,
-        "line_number": 3,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/molecule/secrets.yml",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
     "tests/molecule_it/script.sh": [
       {
         "type": "Secret Keyword",
@@ -277,57 +237,7 @@
         "line_number": 11,
         "is_secret": false
       }
-    ],
-    "tests/test-config-7.0.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-config-7.0.json",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
-    "tests/test-config-7.1.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-config-7.1.json",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
-    "tests/test-config-acs6-stack.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-config-acs6-stack.json",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
-    "tests/test-config-community.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-config-community.json",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
-    ],
-    "tests/test-config.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test-config.json",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_verified": false,
-        "line_number": 5,
-        "is_secret": false
-      }
     ]
   },
-  "generated_at": "2022-10-18T14:41:40Z"
+  "generated_at": "2022-10-25T15:36:16Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -228,15 +228,6 @@
         "is_secret": false
       }
     ],
-    "tests/molecule/secrets.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/molecule/secrets.yml",
-        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
-        "is_verified": false,
-        "line_number": 7
-      }
-    ],
     "tests/molecule_it/script.sh": [
       {
         "type": "Secret Keyword",
@@ -248,5 +239,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-25T15:59:36Z"
+  "generated_at": "2022-10-25T16:03:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -19,6 +19,12 @@
     },
     {
       "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
@@ -45,6 +51,9 @@
     },
     {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
@@ -109,24 +118,126 @@
     }
   ],
   "results": {
-    "roles/repository/tasks/postgres.yml": [
+    "group_vars/all.yml": [
       {
-        "type": "Secret Keyword",
-        "filename": "roles/repository/tasks/postgres.yml",
-        "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "type": "Hex High Entropy String",
+        "filename": "group_vars/all.yml",
+        "hashed_secret": "45bae218333abbfceb487eff1384fc11f9734834",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 150,
+        "is_secret": false
       }
     ],
-    "roles/repository/vars/postgres.yml": [
+    "molecule/default/create.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "roles/repository/vars/postgres.yml",
-        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "filename": "molecule/default/create.yml",
+        "hashed_secret": "6b42874e3cd20771d93096ec5ce36307a1f2ba14",
         "is_verified": false,
-        "line_number": 5
+        "line_number": 240,
+        "is_secret": false
+      }
+    ],
+    "roles/activemq/molecule/default/tests/test_activemq.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/activemq/molecule/default/tests/test_activemq.py",
+        "hashed_secret": "77959ccb2a8f8f16f5eaf783015efea52233cb7f",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "roles/adw/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/adw/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "roles/repository/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "roles/search/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/search/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      }
+    ],
+    "roles/search_enterprise/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/search_enterprise/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "roles/sfs/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/sfs/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 23,
+        "is_secret": false
+      }
+    ],
+    "roles/sync/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/sync/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
+      }
+    ],
+    "roles/transformers/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/transformers/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 78,
+        "is_secret": false
+      }
+    ],
+    "roles/trouter/tasks/main.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/trouter/tasks/main.yml",
+        "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
+        "is_verified": false,
+        "line_number": 73,
+        "is_secret": false
+      }
+    ],
+    "tests/molecule_it/script.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/molecule_it/script.sh",
+        "hashed_secret": "6ed69624421f60a794037509fd6990189ea2997a",
+        "is_verified": false,
+        "line_number": 11,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-02-21T19:09:07Z"
+  "generated_at": "2022-10-18T14:34:40Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -228,6 +228,15 @@
         "is_secret": false
       }
     ],
+    "tests/molecule/secrets.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/molecule/secrets.yml",
+        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
     "tests/molecule_it/script.sh": [
       {
         "type": "Secret Keyword",
@@ -239,5 +248,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-25T15:36:16Z"
+  "generated_at": "2022-10-25T15:59:36Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,12 +109,6 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_secret",
-      "pattern": [
-        "(admin|mp6yc0UD9e|alfresco)"
-      ]
     }
   ],
   "results": {
@@ -158,6 +152,16 @@
         "is_secret": false
       }
     ],
+    "roles/repository/molecule/default/tests/test_repository.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/molecule/default/tests/test_repository.py",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 56,
+        "is_secret": false
+      }
+    ],
     "roles/repository/tasks/main.yml": [
       {
         "type": "Secret Keyword",
@@ -165,6 +169,16 @@
         "hashed_secret": "0eeb6b7bb932e8594b4ffe039dc15332f670cbd9",
         "is_verified": false,
         "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "roles/repository/templates/custom-slingshot-application-context.xml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "roles/repository/templates/custom-slingshot-application-context.xml",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 23,
         "is_secret": false
       }
     ],
@@ -228,6 +242,32 @@
         "is_secret": false
       }
     ],
+    "tests/molecule/secrets.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/molecule/secrets.yml",
+        "hashed_secret": "a4a747bd4ba5e3a5049cad116881867c71fb625b",
+        "is_verified": false,
+        "line_number": 1,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/molecule/secrets.yml",
+        "hashed_secret": "c521bbd712f047dc265cd51ce7484d6848e4ad41",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/molecule/secrets.yml",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
     "tests/molecule_it/script.sh": [
       {
         "type": "Secret Keyword",
@@ -237,7 +277,57 @@
         "line_number": 11,
         "is_secret": false
       }
+    ],
+    "tests/test-config-7.0.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test-config-7.0.json",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
+    "tests/test-config-7.1.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test-config-7.1.json",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
+    "tests/test-config-acs6-stack.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test-config-acs6-stack.json",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
+    "tests/test-config-community.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test-config-community.json",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
+    ],
+    "tests/test-config.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test-config.json",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 5,
+        "is_secret": false
+      }
     ]
   },
-  "generated_at": "2022-10-18T14:34:40Z"
+  "generated_at": "2022-10-18T14:41:40Z"
 }

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -147,7 +147,7 @@ dependencies_url:
   activemq_sha512_checksum_url: "{{ activemq_archive_url }}/{{ dependencies_version.activemq }}/apache-activemq-{{ dependencies_version.activemq }}-bin.tar.gz.sha512"
 
   java: "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-{{ dependencies_version.java }}%2B{{ dependencies_version.java_build }}/OpenJDK11U-jdk_x64_linux_{{ dependencies_version.java }}_{{ dependencies_version.java_build }}.tar.gz"
-  java_md5_checksum: "51f07e93bc4890bbc16fba1780133d68" # pragma: allowlist secret
+  java_md5_checksum: "51f07e93bc4890bbc16fba1780133d68"
 
   tomcat: "{{ tomcat_archive_url }}/tomcat-{{ dependencies_version.tomcat[0] }}/v{{ dependencies_version.tomcat }}/bin/apache-tomcat-{{ dependencies_version.tomcat }}.tar.gz"
   tomcat_sha512_checksum_url: "{{ tomcat_archive_url }}/tomcat-{{ dependencies_version.tomcat[0] }}/v{{ dependencies_version.tomcat }}/bin/apache-tomcat-{{ dependencies_version.tomcat }}.tar.gz.sha512"

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -237,7 +237,7 @@
             - name: "{{ item.ssh_user }}"
               ssh_authorized_keys:
                 - "{{ local_keypairs.results[index].public_key }}"
-              sudo: "ALL=(ALL) NOPASSWD:ALL" # pragma: allowlist secret
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
         platform_cloud_config: >-
           {{ (item.key_inject_method == 'cloud-init')
                | ternary((item.cloud_config | combine(platform_generated_cloud_config)), item.cloud_config) }}

--- a/roles/activemq/molecule/default/tests/test_activemq.py
+++ b/roles/activemq/molecule/default/tests/test_activemq.py
@@ -15,7 +15,7 @@ def get_ansible_vars(host):
     common_vars = "file=../common/vars/main.yml name=common_vars"
     common_defaults = "file=../common/defaults/main.yml name=common_defaults"
     group_vars = "file=../../group_vars/all.yml name=group_vars"
-    secrets_vars = "file=../../vars/secrets.yml name=secrets_vars" # pragma: allowlist secret
+    secrets_vars = "file=../../vars/secrets.yml name=secrets_vars"
     ansible_vars = host.ansible("include_vars", java_role)["ansible_facts"]["java_role"]
     ansible_vars.update(host.ansible("include_vars", common_defaults)["ansible_facts"]["common_defaults"])
     ansible_vars.update(host.ansible("include_vars", common_vars)["ansible_facts"]["common_vars"])

--- a/roles/adw/tasks/main.yml
+++ b/roles/adw/tasks/main.yml
@@ -15,7 +15,7 @@
   get_url:
     url: "{{ downloads.adw_zip_url }}"
     dest: "{{ download_location }}/alfresco-digital-workspace-{{ adw.version }}.zip"
-    checksum: sha1:{{ lookup('url', downloads.adw_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.adw_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     mode: 'u=r,g=r,o=r'
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -67,7 +67,7 @@
   loop: "{{ war_downloads }}"
   get_url:
     url: "{{ item.url }}"
-    checksum: sha1:{{ lookup('url', item.sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', item.sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     dest: "{{ item.dest }}"
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"
@@ -87,7 +87,7 @@
     dest: "{{ download_location }}/{{ acs.artifact_name }}.zip"
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"
-    checksum: sha1:{{ lookup('url', downloads.acs_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.acs_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
   register: distribution_download_result
   async: 1800
   poll: 0
@@ -99,7 +99,7 @@
   loop: "{{ amp_downloads }}"
   get_url:
     url: "{{ item.url }}"
-    checksum: sha1:{{ lookup('url', item.sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', item.sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     dest: "{{ item.dest }}"
     owner: "{{ username }}"
     group: "{{ group_name }}"

--- a/roles/repository/templates/custom-slingshot-application-context.xml
+++ b/roles/repository/templates/custom-slingshot-application-context.xml
@@ -20,7 +20,7 @@
    <hz:hazelcast id="webframework.cluster.slingshot">
       <hz:config>
               <!-- Hazelcast retired group password since 3.9 (at minimum) https://github.com/hazelcast/hazelcast/issues/11667 -->
-	      <hz:group name="slingshot" password="alfresco" /> <!-- pragma: allowlist secret -->
+	      <hz:group name="slingshot" password="alfresco" />
          <hz:network port="5801" port-auto-increment="true">
             <hz:join>
                <hz:multicast enabled="false"

--- a/roles/search/tasks/main.yml
+++ b/roles/search/tasks/main.yml
@@ -8,7 +8,7 @@
   get_url:
     url: "{{ downloads.search_zip_url }}"
     dest: "{{ download_location }}/{{ search.artifact_name }}-{{ search.version }}.zip"
-    checksum: sha1:{{ lookup('url', downloads.search_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.search_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     mode: "0644"
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"

--- a/roles/search/templates/solrcore.properties.j2
+++ b/roles/search/templates/solrcore.properties.j2
@@ -43,11 +43,11 @@ alfresco.secureComms={% if search.version is version('2.0.3', '>=') %}secret{% e
 alfresco.encryption.ssl.keystore.type=JCEKS
 alfresco.encryption.ssl.keystore.provider=
 alfresco.encryption.ssl.keystore.location=ssl.repo.client.keystore
-alfresco.encryption.ssl.keystore.passwordFileLocation=ssl-keystore-passwords.properties # pragma: allowlist secret
+alfresco.encryption.ssl.keystore.passwordFileLocation=ssl-keystore-passwords.properties
 alfresco.encryption.ssl.truststore.type=JCEKS
 alfresco.encryption.ssl.truststore.provider=
 alfresco.encryption.ssl.truststore.location=ssl.repo.client.truststore
-alfresco.encryption.ssl.truststore.passwordFileLocation=ssl-truststore-passwords.properties # pragma: allowlist secret
+alfresco.encryption.ssl.truststore.passwordFileLocation=ssl-truststore-passwords.properties
 
 # Default Tracker
 alfresco.cron=0/10 * * * * ? *

--- a/roles/search_enterprise/tasks/main.yml
+++ b/roles/search_enterprise/tasks/main.yml
@@ -4,7 +4,7 @@
   get_url:
     url: "{{ downloads.search_enterprise_zip_url }}"
     dest: "{{ download_location }}/{{ search_enterprise.artifact_name }}-{{ search_enterprise.version }}.zip"
-    checksum: sha1:{{ lookup('url', downloads.search_enterprise_zip_sha1_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.search_enterprise_zip_sha1_url, username=nexus_user, password=nexus_password) }}
     mode: "0644"
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"

--- a/roles/sfs/tasks/main.yml
+++ b/roles/sfs/tasks/main.yml
@@ -20,7 +20,7 @@
       get_url:
         url: "{{ downloads.sfs_jar_url }}"
         dest: "{{ ats_home }}/{{ sfs.artifact_name }}-{{ sfs.version }}.jar"
-        checksum: sha1:{{ lookup('url', downloads.sfs_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+        checksum: sha1:{{ lookup('url', downloads.sfs_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
         owner: "{{ username }}"
         group: "{{ group_name }}"
         mode: "0644"

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -8,7 +8,7 @@
   get_url:
     url: "{{ downloads.sync_zip_url }}"
     dest: "{{ download_location }}/sync-dist-6.x-{{ sync.version }}.zip"
-    checksum: sha1:{{ lookup('url', downloads.sync_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.sync_zip_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     url_username: "{{ nexus_user }}"
     url_password: "{{ nexus_password }}"
 

--- a/roles/transformers/tasks/main.yml
+++ b/roles/transformers/tasks/main.yml
@@ -75,7 +75,7 @@
       get_url:
         url: "{{ downloads.transform_jar_url }}"
         dest: "{{ binaries_folder }}/transform-service/{{ transform.artifact_name }}-{{ transform.version }}.jar"
-        checksum: sha1:{{ lookup('url', downloads.transform_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+        checksum: sha1:{{ lookup('url', downloads.transform_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
         owner: "{{ username }}"
         group: "{{ group_name }}"
         mode: 'u=rwx,g=rwx,o=rx'

--- a/roles/trouter/tasks/main.yml
+++ b/roles/trouter/tasks/main.yml
@@ -70,7 +70,7 @@
   get_url:
     url: "{{ downloads.trouter_jar_url }}"
     dest: "{{ ats_home }}/{{ trouter.artifact_name }}-{{ trouter.version }}.jar"
-    checksum: sha1:{{ lookup('url', downloads.trouter_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }} # pragma: allowlist secret
+    checksum: sha1:{{ lookup('url', downloads.trouter_jar_sha1_checksum_url, username=nexus_user, password=nexus_password) }}
     owner: "{{ username }}"
     group: "{{ group_name }}"
     mode: 'u=rwx,g=rwx,o=rx'

--- a/tests/molecule/secrets.yml
+++ b/tests/molecule/secrets.yml
@@ -3,5 +3,5 @@ sync_db_password: alfresco
 reposearch_shared_secret: alfresco with space
 activemq_username: admin
 activemq_password: admin
-elasticsearch_username: dummy
-elasticsearch_password: dummy
+elasticsearch_username: alfresco
+elasticsearch_password: alfresco

--- a/tests/molecule_it/script.sh
+++ b/tests/molecule_it/script.sh
@@ -8,7 +8,7 @@ if [ -n "$MOLECULE_IT_SCENARIO" ]; then
         ansible-playbook -e vault_init=encrypted_variables playbooks/secrets-init.yml
     fi
 
-    SECRETS='vars/secrets.yml' # pragma: allowlist secret
+    SECRETS='vars/secrets.yml'
     if [ ! -f "$SECRETS" ]; then
         echo "$SECRETS should exists at this point"
         exit 1


### PR DESCRIPTION
* update detect-secrets to latest version
* remove all pragma to allow secrets AND add them to baseline as not secrets

What I've understood is:
* every time a secret detection get triggered by pre-commit hook:
  * `detect-secrets scan --baseline .secrets.baseline` to add new detections to the baseline
  * `detect-secrets audit .secrets.baseline` to mark that detection as non-secret

OPSEXP-1742