### PR TITLE
OPSEXP-1813: fix wrong routing for alf-ES media cache url

### DIFF
--- a/roles/search_enterprise/molecule/default/converge.yml
+++ b/roles/search_enterprise/molecule/default/converge.yml
@@ -5,12 +5,15 @@
     - name: "Include activemq"
       include_role:
         name: "activemq"
-    - name: "Include transformers"
-      include_role:
-        name: "transformers"
     - name: "Include sfs"
       include_role:
         name: "sfs"
+    - name: "Include transformers"
+      include_role:
+        name: "transformers"
+    - name: "Include t-router"
+      include_role:
+        name: "trouter"
     - name: "Include search_enterprise"
       include_role:
         name: "search_enterprise"

--- a/roles/search_enterprise/molecule/default/verify.yml
+++ b/roles/search_enterprise/molecule/default/verify.yml
@@ -14,13 +14,16 @@
 
     - name: Get errors in the journal of Elasticsearch Connector service
       become: true
-      ansible.builtin.shell: "journalctl -u elasticsearch-connector.service -q | grep -E '(ERROR|WARN)'"
-      failed_when: error_log.rc not in [0,1]
+      ansible.builtin.shell: journalctl -u elasticsearch-connector.service
       register: error_log
 
-    - name: Assert no errors or warnings are present in the service log
+    - name: Check logs for errors, warning and expected patterns
+      vars:
+        log_expected_regex: |-
+          Refreshing accepted content media-type cache, accepted type count: ([7-9]\d|[1-9]\d{2,})$
       ansible.builtin.assert:
         that:
-          - error_log.stdout | length == 0
-          - error_log.stderr | length == 0
+          - not error_log.stdout | regex_search(' WARN ')
+          - not error_log.stderr | regex_search(' ERROR ')
+          - error_log.stdout | regex_search('{{ log_expected_regex }}')
         msg: "{{ error_log.stdout }} {{ error_log.stderr }}"

--- a/roles/search_enterprise/templates/elasticsearch-connector.service.j2
+++ b/roles/search_enterprise/templates/elasticsearch-connector.service.j2
@@ -24,5 +24,7 @@ Restart=on-failure
 RestartSec=60
 SuccessExitStatus=143
 
+WorkingDirectory={{ search_enterprise_binaries_dir }}
+
 [Install]
 WantedBy=multi-user.target

--- a/roles/search_enterprise/templates/elasticsearch-connector.service.j2
+++ b/roles/search_enterprise/templates/elasticsearch-connector.service.j2
@@ -15,7 +15,7 @@ Environment=SPRING_ELASTICSEARCH_REST_URIS={{ elasticsearch_protocol }}://{{ ela
 Environment=SPRING_ELASTICSEARCH_REST_USERNAME={{ elasticsearch_username }}
 Environment=SPRING_ELASTICSEARCH_REST_PASSWORD={{ elasticsearch_password }}
 Environment=ALFRESCO_SHAREDFILESTORE_BASEURL=http://{{ sfs_host }}:{{ ports_cfg.sfs.http }}/alfresco/api/-default-/private/sfs/versions/1/file
-Environment=ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL=http://{{ ats_tengine_aio_host }}:{{ ports_cfg.transformers.tengine }}/transform/config
+Environment=ALFRESCO_ACCEPTED_CONTENT_MEDIA_TYPES_CACHE_BASE_URL=http://{{ trouter_host }}:{{ ports_cfg.transformers.trouter }}/transform/config
 
 ExecStart={{ java_home }}/bin/java -jar {{ search_enterprise_binaries_dir }}/alfresco-elasticsearch-live-indexing-{{ search_enterprise.version }}-app.jar
 ExecStop=/bin/kill -15 $MAINPID


### PR DESCRIPTION
Ref: OPSEXP-1813
Mostly for consistency/corner-cases as Ansible deploys aio  transformer