### PR TITLE
pin pipenv to 2022.10.12

### DIFF
--- a/.github/actions/pipenv/action.yml
+++ b/.github/actions/pipenv/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
   - name: Install pipenv
     shell: bash
-    run: pip install --user pipenv
+    run: pip install --user pipenv==2022.10.12
   - name: Install packages from Pipfile
     shell: bash
     run: pipenv install --deploy --dev


### PR DESCRIPTION
it break very bad with the yesterday release

https://github.com/Alfresco/alfresco-ansible-deployment/actions/runs/3337677442/jobs/5524326683