### PR TITLE
OPSEXP-1891 Switch tests to rockylinux 8

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: true
       matrix:
         molecule_distro:
-          - image: centos:7
           - image: ubuntu:20.04
           - image: rockylinux:8
         role:

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -31,27 +31,6 @@ jobs:
           - name: search
           - name: tomcat
           - name: transformers
-        exclude: # saves some build time building common roles that get tested anyway
-          - molecule_distro:
-              image: rockylinux:8
-            role:
-              name: common
-          - molecule_distro:
-              image: rockylinux:8
-            role:
-              name: java
-          - molecule_distro:
-              image: rockylinux:8
-            role:
-              name: nginx
-          - molecule_distro:
-              image: rockylinux:8
-            role:
-              name: postgres
-          - molecule_distro:
-              image: rockylinux:8
-            role:
-              name: tomcat
     env:
       PY_COLORS: 1
     steps:

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: true
       matrix:
         molecule_distro:
-          - image: centos:7
           - image: ubuntu:20.04
           - image: rockylinux:8
         role:

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -122,7 +122,7 @@ jobs:
         molecule_scenario:
           - name: default
             vars: vars-centos7.yml
-            desc: EC2 ACS 6.2 (Centos7)
+            desc: EC2 ACS 7.0 (Centos7)
           - name: default
             vars: vars-rhel7.yml
             desc: EC2 ACS 7.0 (RHEL7)

--- a/molecule/default/vars-centos7.yml
+++ b/molecule/default/vars-centos7.yml
@@ -1,4 +1,4 @@
 MOLECULE_IT_IMAGE_ID: ami-0b850cf02cc00fdc8
-MOLECULE_IT_EXTRA_VARS: 6.2.N-extra-vars.yml
-MOLECULE_IT_TEST_CONFIG: tests/test-config-acs6-stack.json
+MOLECULE_IT_EXTRA_VARS: 7.0.N-extra-vars.yml
+MOLECULE_IT_TEST_CONFIG: tests/test-config-7.0.json
 MOLECULE_IT_PLATFORM: centos7

--- a/roles/activemq/molecule/default/molecule.yml
+++ b/roles/activemq/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: activemq-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/adw/molecule/default/molecule.yml
+++ b/roles/adw/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: adw-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: common-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: java-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: nginx-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/postgres/molecule/default/molecule.yml
+++ b/roles/postgres/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: postgres-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true
@@ -34,4 +34,4 @@ provisioner:
 verifier:
   name: testinfra
   env:
-    TEST_IMAGE: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    TEST_IMAGE: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}

--- a/roles/repository/molecule/default/molecule.yml
+++ b/roles/repository/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: repository-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/search/molecule/default/molecule.yml
+++ b/roles/search/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: search-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/sfs/molecule/default/molecule.yml
+++ b/roles/sfs/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: sfs-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/sync/molecule/default/molecule.yml
+++ b/roles/sync/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: syncservice-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/tomcat/molecule/default/molecule.yml
+++ b/roles/tomcat/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: tomcat-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/transformers/molecule/default/molecule.yml
+++ b/roles/transformers/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: transformers-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true

--- a/roles/trouter/molecule/default/molecule.yml
+++ b/roles/trouter/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: trouter-instance
-    image: ${MOLECULE_ROLE_IMAGE:-centos:7}
+    image: ${MOLECULE_ROLE_IMAGE:-rockylinux:8}
     dockerfile: ../../../../tests/molecule/Dockerfile-noprivs.j2
     command: "/lib/systemd/systemd"
     privileged: true


### PR DESCRIPTION
Get rid of unreliable centos:7 docker tests

OPSEXP-1891