### PR TITLE
OPSEXP-1741 Enable idempotence checks on EC2 integration tests

### DIFF
--- a/tests/molecule_it/script.sh
+++ b/tests/molecule_it/script.sh
@@ -26,6 +26,8 @@ if [ -n "$MOLECULE_IT_SCENARIO" ]; then
         # shellcheck disable=SC2086
         pipenv run molecule $EXTRA_CONFIG converge -s "$MOLECULE_IT_SCENARIO"
         # shellcheck disable=SC2086
+        pipenv run molecule $EXTRA_CONFIG idempotence -s "$MOLECULE_IT_SCENARIO"
+        # shellcheck disable=SC2086
         pipenv run molecule $EXTRA_CONFIG side-effect -s "$MOLECULE_IT_SCENARIO"
         # shellcheck disable=SC2086
         pipenv run molecule $EXTRA_CONFIG verify -s "$MOLECULE_IT_SCENARIO"


### PR DESCRIPTION
Don’t remember why we skipped idempotence checks for Ansible ec2 integration tests but it should not be really a problem to enable them now.

AC:

The idempotence scenario should be added after converge and before side-effects scenario in [integration test script](https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/tests/molecule_it/script.sh#L27)

EC2 integrations tests should be green