### PR TITLE
Fix OS test check and update supported OSes configuration

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -71,7 +71,7 @@ sync:
     {{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x
   version: 3.8.0
 supported_os:
-  RHEL:
+  RedHat:
     versions:
       - 8.6
       - 8.5

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -79,9 +79,14 @@ supported_os:
       - 8.2
       - 7.7
       - 7.6
+  Rocky:
+    versions:
+      - 8.7
+      - 8.6
   CentOS:
     versions:
       - 7.9
+      - 7.7
   Ubuntu:
     versions:
       - 22.04

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -10,7 +10,7 @@
       msg:
         - "{{ ansible_distribution }} {{ ansible_distribution_version }} is not a supported OS"
     when:
-       - not (skip_os_test | default(false) | bool)
+      - not (skip_os_test | default(false) | bool)
       - ansible_distribution_version | float not in os_versions
 
 - name: Run preliminary checks

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -10,8 +10,8 @@
       msg:
         - "{{ ansible_distribution }} {{ ansible_distribution_version }} is not a supported OS"
     when:
-      - not skip_os_test | default(true) | bool
-      - ansible_distribution_version | int not in os_versions
+      - skip_os_test is undefined or not skip_os_test | default(true) | bool
+      - ansible_distribution_version | float not in os_versions
 
 - name: Run preliminary checks
   ansible.builtin.import_playbook: prerun-checks.yml

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -10,7 +10,7 @@
       msg:
         - "{{ ansible_distribution }} {{ ansible_distribution_version }} is not a supported OS"
     when:
-      - skip_os_test is undefined or not skip_os_test | default(true) | bool
+       - not (skip_os_test | default(false) | bool)
       - ansible_distribution_version | float not in os_versions
 
 - name: Run preliminary checks


### PR DESCRIPTION
**Description:**
Task with name "- name: Compare host OS with supported matrix" is currently being skipped most of the time. This is because "skip_os_test" is undefined and because "ansible_distribution_version | int not in os_versions" is failing as well. The transformation to "INT" means that only the major version is kept (E.g.: RedHat 8.6 >> 8). Since "8" is never present in "os_versions" (which contains 8.2, 8.5, 8.6, etc.), then this check is always skipped. According to the documentation, it is supposed to be the opposite, meaning that it's always executed, except if "-i skip_os_test=true" is added as extra var.

Also, the correct ansible distribution for RedHat is "RedHat" and not "RHEL". This causes the "supported_os" to not find anything in case the target OS is RedHat, c.f. https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#ansible-facts-distribution.

**Solution:**
This PR includes the switch from "RHEL" to "RedHat" in the group_vars/all.yml file as well as the fix of the conditions so that the check is always executed and gives the expected result, meaning:
1. failure if distribution/version doesn't match what is defined in the group_vars/all.yml file
2. skipping if distribution/version matches OR if skip_os_test=true

**Please review**