### PR TITLE
Allow nginx to write logs with SELinux

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -20,6 +20,13 @@
     name: "{{ utils }}"
     state: present
 
+- name: Ensure a SELinux related packages are installed
+  become: true
+  package:
+    name: "{{ utils_selinux }}"
+    state: present
+  when: ansible_selinux.status == 'enabled'
+
 - name: Prepare Alfresco platform installation
   become: true
   block:

--- a/roles/common/vars/CentOS7.yml
+++ b/roles/common/vars/CentOS7.yml
@@ -4,7 +4,9 @@ utils:
   - unzip
   - tar
   - python-lxml
-  - libselinux-python
-  - libsemanage-python
   - gpg
   - curl
+utils_selinux:
+  - libselinux-python
+  - libsemanage-python
+  - policycoreutils

--- a/roles/common/vars/Debian.yml
+++ b/roles/common/vars/Debian.yml
@@ -5,7 +5,9 @@ utils:
   - tar
   - xz-utils
   - python3-lxml
-  - python3-selinux
-  - python3-semanage
   - gpg
   - curl
+utils_selinux:
+  - python3-selinux
+  - python3-semanage
+  - policycoreutils

--- a/roles/common/vars/RedHat.yml
+++ b/roles/common/vars/RedHat.yml
@@ -4,7 +4,9 @@ utils:
   - unzip
   - tar
   - python3-lxml
-  - python3-libselinux
-  - python3-libsemanage
   - gpg
   - curl
+utils_selinux:
+  - python3-libselinux
+  - python3-libsemanage
+  - policycoreutils

--- a/roles/common/vars/RedHat7.yml
+++ b/roles/common/vars/RedHat7.yml
@@ -3,7 +3,9 @@ utils:
   - sudo
   - unzip
   - python-lxml
-  - libselinux-python
-  - libsemanage-python
   - gpg
   - curl
+utils_selinux:
+  - libselinux-python
+  - libsemanage-python
+  - policycoreutils

--- a/roles/common/vars/RedHat8.yml
+++ b/roles/common/vars/RedHat8.yml
@@ -1,9 +1,0 @@
----
-utils:
-  - sudo
-  - unzip
-  - python3-lxml
-  - python3-libselinux
-  - python3-libsemanage
-  - gpg
-  - curl

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -37,5 +37,16 @@
         persistent: true
       when: ansible_selinux.status == "enabled"
 
+    - name: Allow nginx to write logs under {{ logs_folder }}
+      community.general.sefcontext:
+        target: "{{ logs_folder }}(/.*)?"
+        setype: httpd_log_t
+        state: present
+      when: ansible_selinux.status == "enabled"
+
+    - name: Apply new SELinux file context to {{ logs_folder }}
+      ansible.builtin.command: "restorecon -irv {{ logs_folder }}"
+      when: ansible_selinux.status == "enabled"
+
 - name: Vhosts configuration
   import_tasks: vhosts.yml


### PR DESCRIPTION
**Description:**
When using the ansible playbook on a `RHEL 8.6` OS, it fails on the `nginx` part. After investigation, it's because nginx cannot startup due to `SELinux` denying it to write the logs under `{{ logs_folder }}`.

Error:
```
TASK [../roles/nginx : Add required proxy config] ****************************************************************************************************************************************************************************
ok: [aws_testing/mop-alf-ce-nginx]
Friday 31 March 2023  15:55:11 +0000 (0:00:02.097)       0:00:37.473 **********
 [started TASK: ../roles/nginx : Remove legacy vhosts.conf file. on aws_testing/mop-alf-ce-nginx]

TASK [../roles/nginx : Remove legacy vhosts.conf file.] **********************************************************************************************************************************************************************
ok: [aws_testing/mop-alf-ce-nginx]
Friday 31 March 2023  15:55:12 +0000 (0:00:01.164)       0:00:38.638 **********
 [started TASK: Make sure NGINX is running on aws_testing/mop-alf-ce-nginx]

TASK [Make sure NGINX is running] ********************************************************************************************************************************************************************************************
fatal: [aws_testing/mop-alf-ce-nginx]: FAILED! => {"changed": false, "msg": "Unable to start service nginx: Job for nginx.service failed because the control process exited with error code.\nSee \"systemctl status nginx.service\" and \"journalctl -xe\" for details.\n"}
```

And in the audit logs:
```
----
time->Fri Mar 31 17:47:52 2023
type=PROCTITLE msg=audit(1680277672.207:3845): proctitle=2F7573722F7362696E2F6E67696E78002D74
type=SYSCALL msg=audit(1680277672.207:3845): arch=c000003e syscall=257 success=no exit=-13 a0=ffffff9c a1=556459c22cc3 a2=441 a3=1a4 items=0 ppid=1 pid=28739 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="nginx" exe="/usr/sbin/nginx" subj=system_u:system_r:httpd_t:s0 key=(null)
type=AVC msg=audit(1680277672.207:3845): avc:  denied  { append } for  pid=28739 comm="nginx" name="nginx.alfresco.access.log" dev="dm-3" ino=131 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:unlabeled_t:s0 tclass=file permissive=0
----
```

**Solution:**
Adding these two small tasks to first set the custom log folder with the `httpd_log_t` type and then reloading the configuration for this folder (see [Ansible setcontext](https://docs.ansible.com/ansible/2.9/modules/sefcontext_module.html)).

**Notes:**
1- There might be a need to do a similar configuration on the config folder if using SSL (i'm not for now), but it looks like it's using the standard /etc/nginx folder for SSL Certificates so I guess it should be OK with the OOTB.
2- I assume the same would be on Rocky 8.x as well, since SELinux is also enabled by default. So I didn't put any other restrictions / conditions than: when: ansible_selinux.status == "enabled"