### PR TITLE
Fixup selinux idempotency

### DIFF
--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -17,3 +17,8 @@
   service:
     name: nginx
     state: reloaded
+
+- name: Apply new SELinux file contexts
+  ansible.builtin.command: "restorecon -irv {{ item }}"
+  with_items:
+    - "{{ logs_folder }}"

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -19,6 +19,7 @@
     state: reloaded
 
 - name: Apply new SELinux file contexts
+  become: true
   ansible.builtin.command: "restorecon -irv {{ item }}"
   with_items:
     - "{{ logs_folder }}"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -43,10 +43,8 @@
         setype: httpd_log_t
         state: present
       when: ansible_selinux.status == "enabled"
-
-    - name: Apply new SELinux file context to {{ logs_folder }}
-      ansible.builtin.command: "restorecon -irv {{ logs_folder }}"
-      when: ansible_selinux.status == "enabled"
+      notify:
+      - Apply new SELinux file contexts
 
 - name: Vhosts configuration
   import_tasks: vhosts.yml


### PR DESCRIPTION
```
  CRITICAL Idempotence test failed because of the following tasks:
  *  => ../roles/nginx : Apply new SELinux file context to /var/log/alfresco
```

https://github.com/Alfresco/alfresco-ansible-deployment/actions/runs/4618606446/jobs/8166474695?pr=572#step:10:2852