### PR TITLE
OSPEXP-1955: add client mTLS config

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -23,7 +23,7 @@ acs:
   artifact_name: alfresco-content-services-distribution
   edition: Enterprise
   repository: "{{ nexus_repository.development_releases }}"
-  version: 7.4.0-A27
+  version: 7.4.0-A33
 amps:
   aos_module:
     repository: "{{ nexus_repository.releases }}/aos-module/alfresco-aos-module"
@@ -55,15 +55,15 @@ search:
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
-  version: 3.1.0-A5
+  version: 3.1.0-A12
 trouter:
   artifact_name: alfresco-transform-router
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 2.1.0-A5
+  version: 2.1.0-A9
 sfs:
   artifact_name: alfresco-shared-file-store-controller
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 2.1.0-A5
+  version: 2.1.0-A9
 adw:
   artifact_name: alfresco-digital-workspace
   repository: "{{ nexus_repository.enterprise_releases }}"

--- a/roles/transformers/templates/application.properties.j2
+++ b/roles/transformers/templates/application.properties.j2
@@ -1,9 +1,16 @@
 server.ssl.enabled=true
 server.ssl.key-password={{ tengines_keystore.pass | default('') }}
-server.ssl.key-store={{ tengines_keystore.path | quote }}
+server.ssl.key-store=file:{{ tengines_keystore.path | quote }}
 server.ssl.key-store-password={{ tengines_keystore.pass | default('') }}
 server.ssl.key-store-type={{ tengines_keystore.type | default('JCEKS') }}
-server.ssl.trust-store={{ tengines_truststore | default(java_home + '/lib/security/cacerts') }}
+server.ssl.trust-store=file:{{ tengines_truststore | default(java_home + '/lib/security/cacerts') }}
 server.ssl.trust-store-password={{ tengines_truststore_pass | default('changeit') }}
 server.ssl.trust-store-type=JCEKS
 server.ssl.client-auth=need
+
+client.ssl.key-store=file:{{ tengines_keystore.path | quote }}
+client.ssl.key-store-password={{ tengines_keystore.pass | default('') }}
+client.ssl.key-store-type={{ tengines_keystore.type | default('JCEKS') }}
+client.ssl.trust-store=file:{{ tengines_truststore | default(java_home + '/lib/security/cacerts') }}
+client.ssl.trust-store-password={{ tengines_truststore_pass | default('changeit') }}
+client.ssl.trust-store-type=JCEKS


### PR DESCRIPTION
Ref: OPSEXP-1955
Actually not used by the Community transformation architecture but in preparation of OPSEXP-1954 & OPSEXP-1953