### PR TITLE
Add firewall setup and configuration

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -263,12 +263,14 @@ Several roles setup services that listen on TCP ports and several roles wait for
 | repository                  | 8080        | nginx, search, syncservice                               | Yes                     |
 | search                      | 8983        | repository                                               | No                      |
 | transformers (aio t-engine) | 8090        | repository                                               | No                      |
+| transformers (router)       | 8095        | repository                                               | No                      |
+| transformers (sfs)          | 8099        | repository                                               | No                      |
 | syncservice                 | 9090        | nginx                                                    | No                      |
-| adw                         | 80          | nginx                                                    | No                      |
+| adw                         | 8880        | nginx                                                    | No                      |
 | nginx                       | 80          | `<client-ips>`                                           | No                      |
 | nginx                       | 443         | `<client-ips>`                                           | No                      |
 
-> NOTE: The transformers host will also contain the transform router process running on port 8095 and the shared file system process running on 8099 but communication between these components remains local.
+> NOTE: When using the ACS Community, some of these ports do not need to be opened (e.g. transform router/sfs, adw).
 
 ## Configure Your Deployment
 
@@ -750,10 +752,10 @@ To check your inventory file is configured correctly and the control node is abl
 ansible all -m ping -i inventory_ssh.yml
 ```
 
-**Optional** To check if the required ports for the deployment are available on the target machine and we also have connectivity between nodes (ex. repository connecting to the db on 5432) please run the prerequisite-checks playbook before you deploy ACS. If there are any firewalls blocking connectivity this playbook will discover them.
+**Optional** To check if the required ports for the deployment are available on the target machine and we also have connectivity between nodes (ex. repository connecting to the db on 5432) the prerun-network-checks playbook can be executed before you deploy ACS. If there are any firewalls blocking connectivity this playbook will discover them.
 
 ```bash
-pipenv run ansible-playbook playbooks/prerequisite-checks.yml -i inventory_ssh.yml
+pipenv run ansible-playbook playbooks/prerun-network-checks.yml -i inventory_ssh.yml [-e "@community-extra-vars.yml"]
 ```
 
 To deploy ACS 7 Enterprise on the target hosts execute the playbook as the current user using the following command:

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -32,6 +32,9 @@
     - name: Setup
       ansible.builtin.setup:
 
+- name: Make sure the firewall is setup properly
+  ansible.builtin.import_playbook: firewall.yml
+
 - name: Database Role
   hosts: database
   gather_facts: no

--- a/playbooks/firewall.yml
+++ b/playbooks/firewall.yml
@@ -1,0 +1,112 @@
+---
+- name: Configure and enable the firewall on activemq
+  hosts: activemq
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.activemq[activemq_protocol] }}"
+      firewall_sources:
+        - "{{ repo_hosts_list }}"
+        - "{{ sync_hosts_list }}"
+        - "{{ trans_hosts_list }}"
+        - "{{ search_ent_hosts_list }}"
+
+- name: Configure and enable the firewall on database
+  hosts: database
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.postgres.sql }}"
+      firewall_sources:
+        - "{{ repo_hosts_list }}"
+        - "{{ sync_hosts_list }}"
+    when: repo_db_url == ""
+
+- name: Configure and enable the firewall on repository
+  hosts: repository
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.repository.http }}"
+        - "{{ ports_cfg.repository.https }}"
+      firewall_sources:
+        - "{{ nginx_hosts_list }}"
+        - "{{ search_hosts_list }}"
+        - "{{ sync_hosts_list }}"
+
+- name: Configure and enable the firewall on search
+  hosts: search
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.search.http }}"
+      firewall_sources:
+        - "{{ repo_hosts_list }}"
+
+- name: Configure and enable the firewall on transformers
+  hosts: transformers
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.transformers.tengine }}"
+      firewall_sources:
+        - "{{ repo_hosts_list }}"
+    when: acs.edition != "Enterprise"
+
+- name: Configure and enable the firewall on transformers
+  hosts: transformers
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.transformers.tengine }}"
+        - "{{ ports_cfg.transformers.trouter }}"
+        - "{{ ports_cfg.sfs.http }}"
+      firewall_sources:
+        - "{{ repo_hosts_list }}"
+    when: acs.edition == "Enterprise"
+
+- name: Configure and enable the firewall on syncservice
+  hosts: syncservice
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.sync.http }}"
+      firewall_sources:
+        - "{{ nginx_hosts_list }}"
+    when: acs.edition == "Enterprise"
+
+- name: Configure and enable the firewall on adw
+  hosts: adw
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.adw.http }}"
+      firewall_sources:
+        - "{{ nginx_hosts_list }}"
+    when: acs.edition == "Enterprise"
+
+- name: Configure and enable the firewall on nginx
+  hosts: nginx
+  become: true
+  tasks:
+  - include_tasks: "../roles/common/tasks/firewall.yml"
+    vars:
+      firewall_ports:
+        - "{{ ports_cfg.nginx.http }}"
+        - "{{ ports_cfg.nginx.https }}"

--- a/playbooks/prerun-network-checks.yml
+++ b/playbooks/prerun-network-checks.yml
@@ -1,133 +1,157 @@
 ---
-- name: prerequisite checks
+- name: Run preliminary network checks for repository hosts
   hosts: repository
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check db connection
+  - name: Check db connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.database | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.database[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.postgres.sql }}"
       delegate_target: "{{ groups.database | first }}"
     when: repo_db_url == ""
-  - name: check activemq connection
+
+  - name: Check activemq connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.activemq | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.activemq[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.activemq[activemq_protocol] }}"
       delegate_target: "{{ groups.activemq | first }}"
-  - name: check search connection
+    when: groups.activemq | default([]) | length > 0
+
+  - name: Check search connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.search | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.search[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.search.http }}"
       delegate_target: "{{ groups.search | first }}"
-  - name: check sync connection
+    when: groups.search | default([]) | length > 0
+
+  - name: Check sync connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.syncservice | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.syncservice[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.sync.http }}"
       delegate_target: "{{ groups.syncservice | first }}"
-  - name: check sfs connection
+    when:
+      - groups.syncservice | default([]) | length > 0
+      - acs.edition == "Enterprise"
+
+  - name: Check sfs connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.transformers | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.transformers[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.sfs.http }}"
       delegate_target: "{{ groups.transformers | first }}"
-  - name: check trouter connection
+    when: acs.edition == "Enterprise"
+
+  - name: Check trouter connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.transformers | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.transformers[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.transformers.trouter }}"
       delegate_target: "{{ groups.transformers | first }}"
-  - name: check tengine connection
+    when: acs.edition == "Enterprise"
+
+  - name: Check tengine connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.transformers | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.transformers[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.transformers.tengine }}"
       delegate_target: "{{ groups.transformers | first }}"
 
-- name: prerequisite checks
+- name: Run preliminary network checks for search hosts
   hosts: search
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check repo connection
+  - name: Check repo connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.repository | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.repository[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.repository.http }}"
       delegate_target: "{{ groups.repository | first }}"
 
-- name: prerequisite checks
+- name: Run preliminary network checks for transformers hosts
   hosts: transformers
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check activemq connection
+  - name: Check activemq connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.activemq | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.activemq[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.activemq[activemq_protocol] }}"
       delegate_target: "{{ groups.activemq | first }}"
+    when: groups.activemq | default([]) | length > 0
 
-- name: prerequisite checks
+- name: Run preliminary network checks for syncservice hosts
   hosts: syncservice
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check repo connection
+  - name: Check repo connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.repository | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.repository[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.repository.http }}"
       delegate_target: "{{ groups.repository | first }}"
-  - name: check activemq connection
+
+  - name: Check activemq connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.activemq | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.activemq[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.activemq[activemq_protocol] }}"
       delegate_target: "{{ groups.activemq | first }}"
+    when: groups.activemq | default([]) | length > 0
 
-- name: prerequisite checks
+- name: Run preliminary network checks for adw hosts
   hosts: adw
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check repo connection
+  - name: Check repo connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.repository | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.repository[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.repository.http }}"
       delegate_target: "{{ groups.repository | first }}"
 
-- name: prerequisite checks
+- name: Run preliminary network checks for nginx hosts
   hosts: nginx
   become: yes
   roles:
     - role: '../roles/helper_modules'
   tasks:
-  - name: check repo connection
+  - name: Check repo connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.repository | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.repository[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.repository.http }}"
       delegate_target: "{{ groups.repository | first }}"
-  - name: check sync connection
+
+  - name: Check sync connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.syncservice | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.syncservice[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
       checked_port: "{{ ports_cfg.sync.http }}"
       delegate_target: "{{ groups.syncservice | first }}"
-  - name: check adw connection
+    when:
+      - groups.syncservice | default([]) | length > 0
+      - acs.edition == "Enterprise"
+
+  - name: Check adw connection
     include_tasks: "../roles/helper_modules/tasks/check_port.yml"
     vars:
       checked_host: "{% if groups.adw | length == 0 %}127.0.0.1{% else %}{{ hostvars[groups.adw[0]].ansible_host | default('127.0.0.1') }}{% endif %}"
-      checked_port: "8880"
+      checked_port: "{{ ports_cfg.adw.http }}"
       delegate_target: "{{ groups.adw | first }}"
+    when:
+      - groups.adw | default([]) | length > 0
+      - acs.edition == "Enterprise"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -46,10 +46,20 @@ elasticsearch_host: >-
 elasticsearch_protocol: >-
   {{- groups.external_elasticsearch | default([]) | map('extract', hostvars, ['elasticsearch_protocol']) | first | default('http') -}}
 
+# List of all hosts for Firewall
+nginx_hosts_list: "{{ groups.nginx | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+repo_hosts_list: "{{ groups.repository | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+trans_hosts_list: "{{ groups.transformers | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+sync_hosts_list: "{{ groups.syncservice | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+search_hosts_list: "{{ groups.search | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+search_ent_hosts_list: "{{ groups.search_enterprise | default([]) | map('extract', hostvars) | map(attribute='ansible_host') }}"
+
 ports_cfg:
   nginx:
     http: 80
     https: 443
+  adw:
+    http: 8880
   activemq:
     openwire: >-
       {% if groups.external_activemq | default(False) %}

--- a/roles/common/tasks/firewall.yml
+++ b/roles/common/tasks/firewall.yml
@@ -1,0 +1,91 @@
+---
+- name: include common defaults
+  include_vars: ../defaults/main.yml
+
+- name: firewalld - Configure and enable the firewall
+  block:
+    - name: firewalld - Install
+      ansible.builtin.yum:
+        name: firewalld
+        state: present
+        update_cache: true
+
+    - name: firewalld - Ensure the firewall is started
+      ansible.builtin.service:
+        name: firewalld
+        state: started
+        enabled: true
+
+    - name: firewalld - Open the ssh service
+      ansible.posix.firewalld:
+        service: ssh
+        permanent: true
+        immediate: true
+        state: enabled
+
+    - name: firewalld - Open ports needed from specified sources
+      ansible.posix.firewalld:
+        rich_rule: rule family="ipv4" source address="{{ item[1] }}" port protocol="tcp" port="{{ item[0] }}" accept
+        permanent: true
+        immediate: true
+        state: enabled
+      loop: "{{ firewall_ports | product(firewall_sources | flatten | difference([ansible_default_ipv4.address])) | list }}"
+      when: firewall_sources is defined
+
+    - name: firewalld - Open ports needed from any sources
+      ansible.posix.firewalld:
+        port: "{{ item }}/tcp"
+        permanent: true
+        immediate: true
+        state: enabled
+      loop: "{{ firewall_ports }}"
+      when: firewall_sources is undefined
+  when: ansible_os_family == 'RedHat'
+
+- name: ufw - Configure and enable the firewall
+  block:
+    - name: ufw - Install
+      ansible.builtin.apt:
+        name: ufw
+        state: present
+        update_cache: true
+
+    - name: ufw - Deny all incoming requests
+      community.general.ufw:
+        direction: incoming
+        proto: any
+        policy: deny
+
+    - name: ufw - Allow all outgoing requests
+      community.general.ufw:
+        direction: outgoing
+        proto: any
+        policy: allow
+
+    - name: ufw - Open the ssh service
+      community.general.ufw:
+        proto: tcp
+        port: ssh
+        rule: allow
+
+    - name: ufw - Open ports needed from specified sources
+      community.general.ufw:
+        proto: tcp
+        port: "{{ item[0] }}"
+        from: "{{ item[1] }}"
+        rule: allow
+      loop: "{{ firewall_ports | product(firewall_sources | flatten | difference([ansible_default_ipv4.address])) | list }}"
+      when: firewall_sources is defined
+
+    - name: ufw - Open ports needed from any sources
+      community.general.ufw:
+        proto: tcp
+        port: "{{ item }}"
+        rule: allow
+      loop: "{{ firewall_ports }}"
+      when: firewall_sources is undefined
+
+    - name: ufw - Enable the service
+      community.general.ufw:
+        state: enabled
+  when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Hello team,

I spent some time to try to add the firewall configuration. I added support for both `RedHat` and `Debian` family using their default firewall (`firewalld` for RedHat / `ufw` for Debian). It's possible to use firewalld everywhere, but then it might become difficult to manage because you would need to remove ufw first (and it might be already in use), etc...

I based myself on the table provided in the documentation (`TCP Port Configuration section` in `deployment-guide.md`) and in the issue #585 I opened a few days ago. The playbook `firewall.yml` will include the tasks from the file of the same name inside the `common` role. For each group, we define a list of ports that should be accessible and optionally a list of source from where the port needs to be reached. Without source, the firewall will be opened from any source (nginx). In case the source is the same IP as the current host on which the task is being executed, the firewall rule will not be set, as it means it's just a local communication (e.g. when the repo and search are on the same server, it won't put a rule for the Solr port).

I had to define new variables to contain the list of all hosts, even if at the moment the playbook only support 1 nginx for example, I prepare the variables to be able to have has many hosts as needed. Also, I couldn't use the already available variables anyway, because for me they are always null/undefined for remote hosts. I'm not sure if the issue is on my side or if it's a more generic topic, but from what I understand, `ansible_default_ipv4.address` is a fact-based variable, meaning that it's only available/defined for the server on which the task is currently running (where the facts were gathered). Therefore, I couldn't use that because all the variables for `repo_host`, `nginx_host`, etc. have a value of `127.0.0.1` if the host is a remote one. So for example, if a task is executed on `nginx`, then `nginx_host` would have its real IP, but `repo_host`, which should have a remote IP (another IP), actually has `127.0.0.1` because `ansible_default_ipv4.address` is undefined. So it wasn't working for the firewall setup since I needed to know all IPs from anywhere, to be able to run the `firewall.yml` playbook as a standalone. Therefore, I used `ansible_host`, as you can see inside the `roles/common/defaults/main.yml` file.

I added a parameter for the ADW port also, to avoid hardcoded references to `8880`. There are still a few hardcoded references inside the nginx for example, which I didn't touch so far, as there might be other things to take care of.

In regards to the Repository/Share clustering, do you think there is something specific to do for the firewall?

Any other comments/modifications/improvements that you could see in this? Don't hesitate to share and I can update my proposal if needed.

Thanks!