### PR TITLE
Make opensearch suite create shorter resource name

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -76,7 +76,7 @@ jobs:
         molecule_distro:
           - image: ubuntu:20.04
           - image: ubuntu:22.04
-          - image: rockylinux:8
+          - image: rockylinux:8.7
         scenario:
           - name: elasticsearch
           - name: pki

--- a/molecule/opensearch/cleanup.yml
+++ b/molecule/opensearch/cleanup.yml
@@ -10,9 +10,12 @@
       {{ lookup('ansible.builtin.env', 'BRANCH_NAME') }}
     build: >-
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
-    ec2_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
-      {{ ['molecule', it_platform, build, repo_branch] | join('-') | lower | truncate(28, True, '') }}
+      {{ ['molecule', it_platform, build, repo_branch]
+      | join('-')
+      | ansible.builtin.regex_replace('[^a-zA-Z0-9]', build[-1])
+      | lower
+      | truncate(28, True, '') }}
   tasks:
     - name: Destroy Opensearch domain {{ domain_name }}
       community.aws.opensearch:

--- a/molecule/opensearch/cleanup.yml
+++ b/molecule/opensearch/cleanup.yml
@@ -10,9 +10,9 @@
       {{ lookup('ansible.builtin.env', 'BRANCH_NAME') }}
     build: >-
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
-    aws_base_resource_name: "{{ [it_platform, repo_branch, build] | join('_') }}"
+    ec2_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
-      {{ aws_base_resource_name | ansible.builtin.regex_replace('[^a-zA-Z0-9]','-') | lower | truncate(28, True, '') }}
+      {{ ['molecule', it_platform, build, repo_branch] | join('-') | lower | truncate(28, True, '') }}
   tasks:
     - name: Destroy Opensearch domain {{ domain_name }}
       community.aws.opensearch:

--- a/molecule/opensearch/cleanup.yml
+++ b/molecule/opensearch/cleanup.yml
@@ -10,7 +10,7 @@
       {{ lookup('ansible.builtin.env', 'BRANCH_NAME') }}
     build: >-
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
-    aws_base_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
+    aws_base_resource_name: "{{ [it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
       {{ aws_base_resource_name | ansible.builtin.regex_replace('[^a-zA-Z0-9]','-') | lower | truncate(28, True, '') }}
   tasks:

--- a/molecule/opensearch/prepare.yml
+++ b/molecule/opensearch/prepare.yml
@@ -24,7 +24,7 @@
       {{ lookup('ansible.builtin.env', 'BRANCH_NAME') }}
     build: >-
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
-    aws_base_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
+    aws_base_resource_name: "{{ [it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
       {{ aws_base_resource_name | ansible.builtin.regex_replace('[^a-zA-Z0-9]','-') | lower | truncate(28, True, '') }}
     domain_admin: admin
@@ -88,6 +88,7 @@
           security_groups: "{{ ec2_sg | unique }}"
           subnets: "{{ ec2_subnet_ids | unique }}"
         tags:
+          Agent: molecule
           ClientInstances: "{{ molecule_yml.platforms | map(attribute='name') | join('/') }}"
           Owner: Ops Readiness Team
           Department: Engineering

--- a/molecule/opensearch/prepare.yml
+++ b/molecule/opensearch/prepare.yml
@@ -55,7 +55,7 @@
         wait_timeout: 1800
         cluster_config:
           instance_type: c6g.large.search
-          instance_count: 2
+          instance_count: 1
           zone_awareness: false
           dedicated_master: false
         ebs_options:

--- a/molecule/opensearch/prepare.yml
+++ b/molecule/opensearch/prepare.yml
@@ -26,7 +26,11 @@
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
     ec2_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
-      {{ ['molecule', it_platform, build, repo_branch] | join('-') | lower | truncate(28, True, '') }}
+      {{ ['molecule', it_platform, build, repo_branch]
+      | join('-')
+      | ansible.builtin.regex_replace('[^a-zA-Z0-9]', build[-1])
+      | lower
+      | truncate(28, True, '') }}
     domain_admin: admin
   tasks:
     - name: Gather caller info

--- a/molecule/opensearch/prepare.yml
+++ b/molecule/opensearch/prepare.yml
@@ -24,9 +24,9 @@
       {{ lookup('ansible.builtin.env', 'BRANCH_NAME') }}
     build: >-
       {{ lookup('ansible.builtin.env', 'BUILD_NUMBER') }}
-    aws_base_resource_name: "{{ [it_platform, repo_branch, build] | join('_') }}"
+    ec2_resource_name: "{{ ['molecule', it_platform, repo_branch, build] | join('_') }}"
     domain_name: >-
-      {{ aws_base_resource_name | ansible.builtin.regex_replace('[^a-zA-Z0-9]','-') | lower | truncate(28, True, '') }}
+      {{ ['molecule', it_platform, build, repo_branch] | join('-') | lower | truncate(28, True, '') }}
     domain_admin: admin
   tasks:
     - name: Gather caller info
@@ -37,8 +37,13 @@
       amazon.aws.ec2_instance_info:
         filters:
           instance-state-name: running
-          "tag:Name": "{{ aws_base_resource_name }}"
+          "tag:Name": "{{ ec2_resource_name }}"
       register: meta_ec2
+
+    - name: Ensure {{ ec2_resource_name }} EC2 instance present and running
+      ansible.builtin.assert:
+        that: meta_ec2.instances | length == 1
+        fail_msg: "Instances matching filters found: {{ meta_ec2.instances | length }}"
 
     - name: Early secrets loading from vault
       include_vars: ../../vars/secrets.yml
@@ -88,6 +93,7 @@
           security_groups: "{{ ec2_sg | unique }}"
           subnets: "{{ ec2_subnet_ids | unique }}"
         tags:
+          Name: "{{ ec2_resource_name }}"
           Creator: Alfresco/alfresco-ansible-deployment
           Purpose: Molecule opensearch suite
           Owner: Alfresco Ops Readiness

--- a/molecule/opensearch/prepare.yml
+++ b/molecule/opensearch/prepare.yml
@@ -88,10 +88,10 @@
           security_groups: "{{ ec2_sg | unique }}"
           subnets: "{{ ec2_subnet_ids | unique }}"
         tags:
-          Agent: molecule
-          ClientInstances: "{{ molecule_yml.platforms | map(attribute='name') | join('/') }}"
-          Owner: Ops Readiness Team
-          Department: Engineering
+          Creator: Alfresco/alfresco-ansible-deployment
+          Purpose: Molecule opensearch suite
+          Owner: Alfresco Ops Readiness
+          Department: Alfresco Engineering
           Production: false
 
     - name: Gather OpenSearch domain info


### PR DESCRIPTION
with the current max length limitation, opensearch resource on aws during IT get created as:

```
molecule-opensearch-opsexp-N
```

leaving just one digit to avoid collisions