### PR TITLE
OPSEXP-2110 Bump community extra-vars for ACS 7.4.0

### DIFF
--- a/community-extra-vars.yml
+++ b/community-extra-vars.yml
@@ -1,21 +1,18 @@
----
 acs:
   artifact_name: alfresco-content-services-community-distribution
   repository: "{{ nexus_repository.releases }}"
-  version: 7.3.0
+  version: 7.4.0.1
   edition: Community
-
 amps:
   aos_module:
     repository: "{{ nexus_repository.releases }}/aos-module/alfresco-aos-module"
-    version: 1.5.0
+    version: 1.6.0
   googledrive_repo:
     repository: "{{ nexus_repository.releases }}/integrations/alfresco-googledrive-repo-community"
-    version: 3.3.0
+    version: 3.4.0
   googledrive_share:
     repository: "{{ nexus_repository.releases }}/integrations/alfresco-googledrive-repo-community"
-    version: 3.3.0
-
+    version: 3.4.0
 amp_downloads:
   - url: "{{ amps.aos_module.repository }}/{{ amps.aos_module.version }}/alfresco-aos-module-{{ amps.aos_module.version }}.amp"
     sha1_checksum_url: "{{ amps.aos_module.repository }}/{{ amps.aos_module.version }}/alfresco-aos-module-{{ amps.aos_module.version }}.amp.sha1"

--- a/tests/test-config-7.2.json
+++ b/tests/test-config-7.2.json
@@ -22,13 +22,13 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "3.6.0",
+            "version": "3.7.2",
             "installed": true
           }
         ]
       },
       "adw": {
-        "version": "2.9.0"
+        "version": "3.0.0"
       }
     }
   }

--- a/tests/test-config-community.json
+++ b/tests/test-config-community.json
@@ -7,17 +7,17 @@
     "assertions": {
       "acs": {
         "edition": "Community",
-        "version": "7.3.0",
+        "version": "7.4.0",
         "identity": false,
         "modules": [
           {
             "id": "org.alfresco.integrations.google.docs",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "installed": true
           },
           {
             "id": "alfresco-aos-module",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "installed": true
           }
         ]


### PR DESCRIPTION
Ref: OPSEXP-2110

didn't use updatecli because we don't support it and not trivial to do (had to skip targets which are not present in community version)