### PR TITLE
OPSEXP-2155 Make plantuml workflow autocommit configured as per docs

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -18,6 +18,7 @@ jobs:
   docker:
     name: ${{ matrix.role.name }} on ${{ matrix.molecule_distro.image }}
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'Alfresco'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -1,7 +1,7 @@
 name: Generate PlantUML Diagrams
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "**.puml"
   push:
@@ -20,6 +20,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # https://github.com/stefanzweifel/git-auto-commit-action#workflow-should-run-in-base-repository
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
 
       - name: Get changed puml
         id: changed-files

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          # https://github.com/stefanzweifel/git-auto-commit-action#workflow-should-run-in-base-repository
+          # https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 


### PR DESCRIPTION
As per https://github.com/stefanzweifel/git-auto-commit-action#use-in-forks-from-public-repositories

I tried directly on https://github.com/Alfresco/alfresco-ansible-deployment/pull/607 but it doesn't trigger when using `pull_request_target` and I suspect we need this merged on default branch before it get triggered

Ref: OPSEXP-2155