### PR TITLE
OPSEXP-1280: refactor acs repo properties file generation

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -13,21 +13,14 @@ the expanding usage of single pages applications and setups where such an
 application is hosted on a domain name which do not match the backend server.
 
 In such circumstances, you can tell the playbook which are these applications
-by using adding the client application to your inventory file as shown below:
+by using adding the client application URL as a repository group variable in the
+`group_vars/repository.yaml` file:
 
 ```yaml
-all:
-  chidren:
-    other_repo_clients:
-      hosts:
-        my_custom_app:
-          known_urls:
-            - http://app.domain.local/legit
-            - https://app.domain.local/legit
+known_urls:
+  - http://app.domain.local/legit
+  - https://app.domain.local/legit
 ```
-
-Note the `known_urls` variable. It needs to be defined as a list of URLs where
-the client application is hosted.
 
 ## Configure CSRF
 
@@ -111,18 +104,13 @@ role), and as a consequence will always try to access the repo through the
 `localhost` interface. That means from the repo's point of view - unless Share
 itself is accessed using [http://localhost/share/](http://localhost/share/) -
 it is breaking CORS protection. For that reason in order for Share to work, it
-is mandatory to add the URL Share will be accessed from as `known_urls`. One
-way to do it is to add this variable to the `repository` group as shown bellow:
+is mandatory to add the URL Share will be accessed from as a `known_urls`.
+We recommand doing it via the `repository` group variables in
+`group_vars/repository.yml`:
 
 ```yaml
-all:
-  chidren:
-    repository:
-      vars:
-        known_urls:
-          - https://ecm.domain.local/share
-      hosts:
-        repository_1:
+known_urls:
+  - https://ecm.domain.local/share
 ```
 
 ## Transformations security

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -816,29 +816,40 @@ There are some useful argument you can use with `ansible-playbook` command in ma
 
 ## ACS cluster
 
-Due to load or high availability needs, you might want to deploy a cluster of several repository nodes. This can be achieved rather simply by:
+Due to load or high availability needs, you might want to deploy a cluster of
+several repository nodes. This can be achieved rather simply by:
 
-* Giving the playbook the location of the shared storage used for the ACS contentstore (See [Shared storage documentation](shared-contentstore.md) for details).
+* Giving the playbook the location of the shared storage used for the ACS
+  contentstore (See [Shared storage documentation](shared-contentstore.md) for
+  details).
 * Specifying several hosts within the repository hosts group
 
-> :warning: as mention in the [Alfresco official documentation](https://docs.alfresco.com/content-services/latest/admin/cluster/#scenarioredundancycluster), "All the servers in a cluster should have static IP addresses assigned to them".
-> Not meeting this pre-requisite won't prevent the playbook from working but the cluster might will most likely stop working in case one of the server in the architecture changes IP address.
+> :warning: as mention in the
+> [Alfresco official documentation](https://docs.alfresco.com/content-services/latest/admin/cluster/#scenarioredundancycluster),
+> "All the servers in a cluster should have static IP addresses assigned to
+> them".
 
-For example:
+For example in the inventory file:
 
 ```yaml
 ...
     repository:
-      vars:
-        cs_storage:
-          type: nfs
-          device: nas.infra.local:/exports/contentstore
-          options: _netdev,noatime,nodiratim
       hosts:
         ecm1.infra.local:
         ecm2.infra.local:
         ingester.infra.local:
           cluster_keepoff: true
+...
+```
+
+In the `group_vars/repository.yml` file:
+
+```yaml
+...
+cs_storage:
+  type: nfs
+  device: nas.infra.local:/exports/contentstore
+  options: _netdev,noatime,nodiratim
 ...
 ```
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -410,9 +410,19 @@ And then edit `vars/secrets.yml` to fill all the required arguments for the plug
 
 ### Alfresco Global Properties
 
-You can provide your [repository configuration](https://github.com/Alfresco/acs-deployment/blob/master/docs/properties-reference.md) by editing the `configuration_files/alfresco-global.properties` file.
+You can provide your [repository
+configuration](https://github.com/Alfresco/acs-deployment/blob/master/docs/properties-reference.md)
+by editing the `configuration_files/alfresco-global.properties` file.
 
-The properties defined in this file will be appended to the generated "alfresco-global.properties" located in "/etc/opt/alfresco/content-services/classpath".
+> This approach is now discoraged and you should prefer using the [`repository`
+> group vars](../configuration_files/alfresco-global.properties)
+> `global_properties` as much as possible otherwise reference you own snippets
+> of properties file using either the new `repository` group var
+> `properties_snippets` or directly the `repository` role argument
+> `raw_properties`.
+
+`alfresco-global.properties` will be located in
+`/etc/opt/alfresco/content-services/classpath`.
 
 ### Enable SSL
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -414,7 +414,7 @@ You can provide your [repository
 configuration](https://github.com/Alfresco/acs-deployment/blob/master/docs/properties-reference.md)
 by editing the `configuration_files/alfresco-global.properties` file.
 
-> This approach is now discoraged and you should prefer using the [`repository`
+> This approach is now discouraged and you should prefer using the [`repository`
 > group vars](../configuration_files/alfresco-global.properties)
 > `global_properties` as much as possible otherwise reference you own snippets
 > of properties file using either the new `repository` group var

--- a/docs/playbook-upgrade.md
+++ b/docs/playbook-upgrade.md
@@ -2,6 +2,23 @@
 
 ## Unreleased version
 
+### Passing Alfresco global properties
+
+In previous version we provided an empty `alfresco-global.properties` file to
+conveniently pass static configuration for ACS repository. We're deprecating
+this.
+Instead we now accept a list of file(s) that can be passed to the `repository`
+role as a role argument. Within the role the default value of the argument
+(`raw_properties`) is empty, but the playbook sets a values for it using
+`repository` group vars. This ensure backward compatibility for now, but be
+aware that we will remove this from next major version.
+
+The newer approach is just to use the `global_properties` in the `repository`
+group var as much as possible, and if you really need to include a snippet of
+properties from a file, reference this file in the `properties_snippets` in
+the same `repository` group vars (which will be passed automatically by the
+playbook to the `raw_properties` role argument).
+
 ## v2.1.0
 
 ### Secrets management

--- a/docs/shared-contentstore.md
+++ b/docs/shared-contentstore.md
@@ -12,9 +12,9 @@ contentstore
 └── 2022
     └── 2
         ├── 17
-        │   └── 18
-        │       ├── 54
-        │       └── 55
+        │   └── 18
+        │       ├── 54
+        │       └── 55
         └── 18
             └── 2
                 ├── 22
@@ -55,17 +55,20 @@ cs_storage:
   options:
 ```
 
-Given this variable defines a chunk of the deployment architecture we recommend you set it in the ansible inventory file. The file `inventory_ha.yml` gives an example of how to use that feature.
-
 #### Typical clusters
 
-For most clusters setting the `cs_storage` variable under the `repository` group is sensible as it makes that config available to all cluster nodes without repeating the config in different places. This is what is done in the example file `inventory_ha.yml` and match most case such as those shown below:
+For most clusters setting the `cs_storage` variable ath the `repository` group
+level is sensible as it makes that config available to all cluster nodes in a
+single declaration. An example snippet is available in the
+`group_vars/repository.yml` file and match most case such as those shown below:
 
 ![ACS basic cluster storage](resources/acs-ha-contentstore.png)
 
 #### Advanced use cases
 
-There may be cases where the configuration required to mount the filesystem on each host might differ. In this case the configuration can be repeated for each repository node, as shown below:
+There may be cases where the configuration required to mount the filesystem on
+each host differs. In this case the configuration can be repeated for each
+repository node, as shown below:
 
 ```yaml
 ---
@@ -84,7 +87,11 @@ all:
               options: _netdev,noatime,nodiratime,tcp,soft,intr
 ```
 
-> The example above could be used in case of sites replicated real-time through low latency links between sites. That's a feature high storage vendors can offer.
+It is also possible to leverage the inventory's `host_vars` file
+
+> The example above could be used in case of sites replicated real-time through
+> low latency links between sites. That's a feature high storage vendors can
+> offer.
 
 ## Dealing with permissions
 

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -44,5 +44,5 @@ global_properties:
   aos:
     baseUrlOverwrite: >-
       {{ acs_play_proto }}://{{ fqdn_alfresco | default(nginx_host) }}:{{ acs_play_port }}/alfresco/aos
-properties_snitppets:
+properties_snippets:
   - ../../configuration_files/alfresco-global.properties

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -31,7 +31,7 @@ global_properties:
     port: "{{ acs_play_port }}"
     protocol: "{{ acs_play_proto }}"
     cluster:
-      enabled: "{{ groups['repository'] | length > 1 and not cluster_keepoff | bool | lower }}"
+      enabled: "{{ (groups['repository'] | length > 1 and not (cluster_keepoff | bool)) | lower }}"
   share:
     host: "{{ fqdn_alfresco | default(known_urls[0]) | default(nginx_host) }}"
     port: "{{ acs_play_port }}"

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -22,7 +22,7 @@ acs_play_port: >-
 global_properties:
   db:
     url: >-
-      {{ repo_db_url | default('jdbc:postgresql://' + db_host + ':' + ports_cfg.postgres.sql + '/' + repo_db_name) }}
+      {{ repo_db_url if repo_db_url else 'jdbc:postgresql://' + db_host + ':' + ports_cfg.postgres.sql | string + '/' + repo_db_name }}
     driver: "{{ repo_db_driver }}"
     username: "{{ repo_db_username }}"
     password: "{{ repo_db_password }}"

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -20,8 +20,6 @@ acs_play_proto: "{{ 'https' if use_ssl | bool else 'http' }}"
 acs_play_port: >-
   {{ ports_cfg.nginx.https if use_ssl | bool else ports_cfg.nginx.http }}
 global_properties:
-  deployment:
-    method: ANSIBLE
   db:
     url: >-
       {{ repo_db_url | default('jdbc:postgresql://' + db_host + ':' + ports_cfg.postgres.sql + '/' + repo_db_name) }}
@@ -33,15 +31,11 @@ global_properties:
     port: "{{ acs_play_port }}"
     protocol: "{{ acs_play_proto }}"
     cluster:
-      enabled: "{{ if groups['repository'] | length > 1 and not cluster_keepoff | bool }}"
+      enabled: "{{ groups['repository'] | length > 1 and not cluster_keepoff | bool | lower }}"
   share:
     host: "{{ fqdn_alfresco | default(known_urls[0]) | default(nginx_host) }}"
     port: "{{ acs_play_port }}"
     protocol: "{{ acs_play_proto }}"
-  dir:
-    root: "{{ data_folder }}/content-services"
-    license:
-      external: "{{ config_folder }}/content-services/licenses"
   messaging:
     broker:
       url: failover:({{ activemq_transport }}://{{ activemq_host }}:{{ ports_cfg.activemq[activemq_protocol] }})?timeout=3000

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -1,0 +1,52 @@
+---
+# Add at least the Share url bellow
+# For more information please have a look at the
+# [security_doc](https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/docs/SECURITY.md#specify-trustworthy-applications)
+known_urls: []
+
+# To enable clustering you need to describe the shared contentstore.
+# Any storage type can be used as long as it can be mounted by the target hosts
+# using the mount(8) command.  # For more details about configuring a shared
+# contentstore for cluster see the
+# [storage_doc](https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/docs/shared-contentstore.md)
+#
+# cs_storage:
+#   type: nfs
+#   device: nas.infra.local:/exports/contentstore
+#   # as in `mount -o` options
+#   options: _netdev,noatime,nodiratime
+
+acs_play_proto: "{{ 'https' if use_ssl | bool else 'http' }}"
+acs_play_port: >-
+  {{ ports_cfg.nginx.https if use_ssl | bool else ports_cfg.nginx.http }}
+global_properties:
+  deployment:
+    method: ANSIBLE
+  db:
+    url: >-
+      {{ repo_db_url | default('jdbc:postgresql://' + db_host + ':' + ports_cfg.postgres.sql + '/' + repo_db_name) }}
+    driver: "{{ repo_db_driver }}"
+    username: "{{ repo_db_username }}"
+    password: "{{ repo_db_password }}"
+  alfresco:
+    host: "{{ fqdn_alfresco | default(nginx_host) }}"
+    port: "{{ acs_play_port }}"
+    protocol: "{{ acs_play_proto }}"
+    cluster:
+      enabled: "{{ if groups['repository'] | length > 1 and not cluster_keepoff | bool }}"
+  share:
+    host: "{{ fqdn_alfresco | default(known_urls[0]) | default(nginx_host) }}"
+    port: "{{ acs_play_port }}"
+    protocol: "{{ acs_play_proto }}"
+  dir:
+    root: "{{ content_data_folder }}/content"
+    license:
+      external: "{{ settings_folder }}/licenses"
+  messaging:
+    broker:
+      url: failover:({{ activemq_transport }}://{{ activemq_host }}:{{ ports_cfg.activemq[activemq_protocol] }})?timeout=3000
+      username: "{{ activemq_username }}"
+      password: "{{ activemq_password }}"
+  aos:
+    baseUrlOverwrite: >-
+      {{ acs_play_proto }}://{{ fqdn_alfresco | default(nginx_host) }}:{{ acs_play_port }}/alfresco/aos

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -44,3 +44,5 @@ global_properties:
   aos:
     baseUrlOverwrite: >-
       {{ acs_play_proto }}://{{ fqdn_alfresco | default(nginx_host) }}:{{ acs_play_port }}/alfresco/aos
+properties_snitppets:
+  - ../../configuration_files/alfresco-global.properties

--- a/group_vars/repository.yml
+++ b/group_vars/repository.yml
@@ -39,9 +39,9 @@ global_properties:
     port: "{{ acs_play_port }}"
     protocol: "{{ acs_play_proto }}"
   dir:
-    root: "{{ content_data_folder }}/content"
+    root: "{{ data_folder }}/content-services"
     license:
-      external: "{{ settings_folder }}/licenses"
+      external: "{{ config_folder }}/content-services/licenses"
   messaging:
     broker:
       url: failover:({{ activemq_transport }}://{{ activemq_host }}:{{ ports_cfg.activemq[activemq_protocol] }})?timeout=3000

--- a/inventory_ha.yml
+++ b/inventory_ha.yml
@@ -17,15 +17,6 @@ all:
       hosts:
         db.infra.local:
     repository:
-      vars:
-        # Add at least Share URL bellow
-        known_urls: []
-        # Every storage that can be enabled via `mount` on hosts is supported
-        cs_storage:
-          type: nfs
-          device: nas.infra.local:/exports/contentstore
-          # as in `mount -o` options
-          options: _netdev,noatime,nodiratime
       hosts:
         ecm1.infra.local:
         ecm2.infra.local:

--- a/inventory_ssh.yml
+++ b/inventory_ssh.yml
@@ -17,9 +17,6 @@ all:
         database_1:
           ansible_host: targetIP
     repository:
-      vars:
-        # Add at least the Share url bellow
-        known_urls: []
       hosts:
         repository_1:
           ansible_host: targetIP

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -168,7 +168,7 @@
     - role: "../roles/repository"
       repo_keystore: "{{ repository_keystore | default({}) }}"
       repository_properties: "{{ global_properties }}"
-      raw_properties: "{{ properties_snitppets }}"
+      raw_properties: "{{ properties_snippets }}"
   post_tasks:
     - name: Update installation status file with ACS
       become: true

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -168,6 +168,7 @@
     - role: "../roles/repository"
       repo_keystore: "{{ repository_keystore | default({}) }}"
       repository_properties: "{{ global_properties }}"
+      raw_properties: "{{ properties_snitppets }}"
   post_tasks:
     - name: Update installation status file with ACS
       become: true

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -167,6 +167,7 @@
   roles:
     - role: "../roles/repository"
       repo_keystore: "{{ repository_keystore | default({}) }}"
+      repository_properties: "{{ global_properties }}"
   post_tasks:
     - name: Update installation status file with ACS
       become: true

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -45,10 +45,14 @@ cors:
   support.credentials: true
   preflight_maxage: 10
 
-# default_repository_properties: properties to be added to the alfresco-global.properties file
-# e.g: alfresco.authentication.allowGuestLogin is disabled by default
-# To add more or override existing defaults, use repository_properties data structure instead of this one.
+# default_repository_properties: properties to be added to the
+# alfresco-global.properties file, e.g: alfresco.authentication.allowGuestLogin
+# is disabled by default.
+# To add more properties or override existing defaults, use the date structure
+# named repository_properties data structure instead of this one.
 default_repository_properties:
+  deployment:
+    method: ANSIBLE
   authentication:
     protection:
       enabled: "true"
@@ -57,6 +61,10 @@ default_repository_properties:
   alfresco:
     authentication:
       allowGuestLogin: "false"
+  dir:
+    root: "{{ content_data_folder }}/content"
+    license:
+      external: "{{ settings_folder }}/licenses"
 
 utils_repo: []
 utils_storage:

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -65,6 +65,7 @@ default_repository_properties:
     root: "{{ content_data_folder }}/content"
     license:
       external: "{{ settings_folder }}/licenses"
+raw_properties: []
 
 utils_repo: []
 utils_storage:

--- a/roles/repository/meta/argument_specs.yml
+++ b/roles/repository/meta/argument_specs.yml
@@ -3,6 +3,13 @@ argument_specs:
   main:
     short_description: Main entrypoint for the repository role
     options:
+      repository_properties:
+        type: dict
+        required: false
+        description: |
+          A YAML data structure containing all the properties you want to set
+          in the alfresco-global.properties file. YAML of each leaf node is
+          expanded as a path separated by '.' (e.g. alfresco.cluster.enabled)
       repo_keystore:
         type: dict
         required: false

--- a/roles/repository/meta/argument_specs.yml
+++ b/roles/repository/meta/argument_specs.yml
@@ -3,6 +3,14 @@ argument_specs:
   main:
     short_description: Main entrypoint for the repository role
     options:
+      raw_properties:
+        type: list
+        required: false
+        default: []
+        elements: str
+        description: |
+          a list of file path containing properties to include as-is in the
+          alfresco-global.properties.
       repository_properties:
         type: dict
         required: false

--- a/roles/repository/molecule/default/converge.yml
+++ b/roles/repository/molecule/default/converge.yml
@@ -1,13 +1,8 @@
 ---
 - name: Converge
   hosts: all
-  tasks:
-    - name: "Include postgres"
-      ansible.builtin.include_role:
-        name: "postgres"
-    - name: "Include activemq"
-      ansible.builtin.include_role:
-        name: "activemq"
-    - name: "Include repository"
-      ansible.builtin.include_role:
-        name: "repository"
+  roles:
+    - role: postgres
+    - role: activemq
+    - role: repository
+      repository_properties: "{{ global_properties }}"

--- a/roles/repository/molecule/default/converge.yml
+++ b/roles/repository/molecule/default/converge.yml
@@ -6,3 +6,5 @@
     - role: activemq
     - role: repository
       repository_properties: "{{ global_properties }}"
+      raw_properties:
+        - ../../configuration_files/alfresco-global.properties

--- a/roles/repository/molecule/default/host_vars/repository-instance.yml
+++ b/roles/repository/molecule/default/host_vars/repository-instance.yml
@@ -34,8 +34,8 @@ acs_play_port: >-
 global_properties:
   authentication:
     protection:
-      limit: 5
-      periodSeconds: 60
+      limit: 3
+      periodSeconds: 20
   db:
     url: jdbc:postgresql://localhost/alfresco
     driver: org.postgresql.Driver

--- a/roles/repository/molecule/default/host_vars/repository-instance.yml
+++ b/roles/repository/molecule/default/host_vars/repository-instance.yml
@@ -1,3 +1,4 @@
+---
 ansible_user: ansible
 bssrf_protection_enabled: true
 known_urls:
@@ -26,8 +27,32 @@ acs_environment:
     - -Dmetadata-keystore.metadata.password=mp6yc0UD9e
     - -Dmetadata-keystore.metadata.algorithm=AES
     - $JAVA_TOOL_OPTIONS
-repository_properties:
+
+acs_play_proto: "{{ 'https' if use_ssl | bool else 'http' }}"
+acs_play_port: >-
+  {{ ports_cfg.nginx.https if use_ssl | bool else ports_cfg.nginx.http }}
+global_properties:
   authentication:
     protection:
       limit: 5
       periodSeconds: 60
+  db:
+    url: jdbc:postgresql://localhost/alfresco
+    driver: org.postgresql.Driver
+    username: "{{ repo_db_username }}"
+    password: "{{ repo_db_password }}"
+  alfresco:
+    host: localhost
+    port: 8080
+    protocol: http
+    cluster:
+      enabled: false
+  share:
+    host: localhost
+    port: 8080
+    protocol: http
+  messaging:
+    broker:
+      url: failover:(tcp://localhost:61616)?timeout=3000
+  aos:
+    baseUrlOverwrite: http://localhost/alfresco/aos

--- a/roles/repository/molecule/default/molecule.yml
+++ b/roles/repository/molecule/default/molecule.yml
@@ -35,7 +35,7 @@ provisioner:
     - "@../../tests/test-extra-vars.yml"
   config_options:
     defaults:
-      pipelining: True
+      pipelining: true
   inventory:
     links:
       group_vars: ../../../../group_vars

--- a/roles/repository/molecule/default/tests/test_repository.py
+++ b/roles/repository/molecule/default/tests/test_repository.py
@@ -36,7 +36,7 @@ def brute_lock_admin(host):
     login_api_endpoint = '/alfresco/api/-default-/public/authentication/versions/1/tickets'
     api_headers = 'Content-Type: application/json'
     repovars = host.ansible.get_variables()
-    iternum = int(repovars['repository_properties']['authentication']['protection']['limit'])
+    iternum = int(repovars['global_properties']['authentication']['protection']['limit'])
     for _ in range(iternum):
         login_payload = '{"userId":"admin","password":"' + ''.join(random.choice(string.ascii_lowercase) for i in range(3)) + '"}'
         host.run("curl http://{}:8080{} -H '{}' -d '{}'".format(
@@ -60,7 +60,7 @@ def test_bruteforce_mitigation(host):
     cmd = host.run("curl http://{}:8080{} -H '{}' -d '{}'".format(test_host,
                    login_api_endpoint, api_headers, login_payload))
     assert_that(json.loads(cmd.stdout)['error']['errorKey'] == 'Login failed')
-    time.sleep(repovars['repository_properties']['authentication']['protection']['periodSeconds'])
+    time.sleep(repovars['global_properties']['authentication']['protection']['periodSeconds'])
     cmd = host.run("curl http://{}:8080{} -H '{}' -d '{}'".format(test_host,
                    login_api_endpoint, api_headers, login_payload))
     assert_that(json.loads(cmd.stdout)['entry']['userId'] == 'admin')

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -355,7 +355,7 @@
         owner: "{{ username }}"
         group: "{{ group_name }}"
         src: alfresco-global.properties.j2
-        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name }}_00-repository.properties"
+        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name | basename }}_00-repository.properties"
         mode: "0640"
       notify: []
 
@@ -369,7 +369,7 @@
     - name: Add snippet from custom config files {{ raw_properties | join(',') }}
       ansible.builtin.copy:
         src: "{{ item }}"
-        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name }}_{{ item | basename }}"
+        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name | basename }}_{{ item | basename }}"
         owner: "{{ username }}"
         group: "{{ group_name }}"
         mode: "0640"
@@ -379,7 +379,7 @@
     - name: Assemble alfresco-global.properties snippets
       ansible.builtin.assemble:
         src: "{{ download_location }}"
-        regexp: assemble_snippets_{{ ansible_role_name }}_.*
+        regexp: assemble_snippets_{{ ansible_role_name | basename }}_.*
         dest: "{{ settings_folder }}/classpath/alfresco-global.properties"
         owner: "{{ username }}"
         group: "{{ group_name }}"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -345,7 +345,7 @@
         path: "{{ content_folder }}/web-server/conf"
         state: absent
 
-    - name: Create alfresco-global.properties
+    - name: Create alfresco-global.properties main snippet
       vars:
         merged_repository_properties: >-
           {{ default_repository_properties
@@ -355,10 +355,35 @@
         owner: "{{ username }}"
         group: "{{ group_name }}"
         src: alfresco-global.properties.j2
-        dest: "{{ settings_folder }}/classpath/alfresco-global.properties"
+        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name }}_00-repository.properties"
         mode: "0640"
-      tags:
-        - molecule-idempotence-notest  # see OPSEXP-1280
+      notify: []
+
+    - name: Check raw snippet can be parsed
+      any_errors_fatal: true
+      ansible.builtin.assert:
+        that: lookup('ansible.builtin.ini', '', type='properties',  file=item) is string
+      notify: []
+      loop: "{{ raw_properties }}"
+
+    - name: Add snippet from custom config files {{ raw_properties | join(',') }}
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ download_location }}/assemble_snippets_{{ ansible_role_name }}_{{ item | basename }}"
+        owner: "{{ username }}"
+        group: "{{ group_name }}"
+        mode: "0640"
+      notify: []
+      loop: "{{ raw_properties }}"
+
+    - name: Assemble alfresco-global.properties snippets
+      ansible.builtin.assemble:
+        src: "{{ download_location }}"
+        regexp: assemble_snippets_{{ ansible_role_name }}_.*
+        dest: "{{ settings_folder }}/classpath/alfresco-global.properties"
+        owner: "{{ username }}"
+        group: "{{ group_name }}"
+        mode: "0640"
 
     - name: Setup common loader
       ansible.builtin.lineinfile:
@@ -370,22 +395,6 @@
           "{{ content_folder }}/web-server/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
         owner: "{{ username }}"
         group: "{{ group_name }}"
-
-    - name: >-
-        Insert or Update custom properties added through
-        configuration_files/alfresco-global.properties
-      ansible.builtin.blockinfile:
-        path: "{{ settings_folder }}/classpath/alfresco-global.properties"
-        marker: "{mark} - ANSIBLE MANAGED BLOCK"
-        marker_begin: "### Begin - Custom user properties"
-        marker_end: "### End - Custom user properties"
-        insertafter: EOF
-        block: >-
-          {{ lookup('file', role_path + '/../../configuration_files/alfresco-global.properties') }}
-        owner: "{{ username }}"
-        group: "{{ group_name }}"
-      tags:
-        - molecule-idempotence-notest  # see OPSEXP-1280
 
 - name: Check on amp download async task
   become: true

--- a/roles/repository/templates/alfresco-global.properties.j2
+++ b/roles/repository/templates/alfresco-global.properties.j2
@@ -1,29 +1,6 @@
-{% if acs.version is version('7.0.0', '>=') %}
-deployment.method=ANSIBLE
-{% endif %}
-
-{% if repo_db_url == "" %}
-db.url=jdbc:postgresql://${db.host}:{{ ports_cfg.postgres.sql }}/{{ repo_db_name }}
-db.host={{ db_host }}
-{% else %}
-db.url={{ repo_db_url }}
-{% endif %}
-
-db.driver={{ repo_db_driver }}
-db.username={{ repo_db_username }}
-db.password={{ repo_db_password }}
-
-alfresco.host={% if fqdn_alfresco %}{{ fqdn_alfresco }}{% else %}{{ nginx_host }}{% endif %}
-
-alfresco.port={% if use_ssl | bool %}{{ ports_cfg.nginx.https }}{% else %}{{ ports_cfg.nginx.http }}{% endif %}
-
-alfresco.protocol={% if use_ssl | bool %}https{% else %}http{% endif %}
-
-share.host={% if fqdn_alfresco %}{{ fqdn_alfresco }}{% else %}{{ nginx_host }}{% endif %}
-
-share.port={% if use_ssl | bool %}{{ ports_cfg.nginx.https }}{% else %}{{ ports_cfg.nginx.http }}{% endif %}
-
-share.protocol={% if use_ssl | bool %}https{% else %}http{% endif %}
+{% for prop in lookup('ansible.utils.to_paths', merged_repository_properties) | dict2items %}
+{{ prop.key }}={{ prop.value }}
+{% endfor %}
 
 {% if groups['search'] | default([]) | length >= 1 %}
 index.subsystem.name=solr6
@@ -42,9 +19,6 @@ elasticsearch.password={{ elasticsearch_password | default('') }}
 {% else %}
 index.subsystem.name=noindex
 {% endif %}
-
-dir.root={{ content_data_folder }}/content
-dir.license.external={{ settings_folder }}/licenses
 
 # KEYSTORES
 
@@ -65,8 +39,6 @@ httpclient.config.transform.mTLSEnabled=true
 httpclient.config.transform.hostnameVerificationDisabled=true
 {% endif %}
 
-alfresco.cluster.enabled={% if groups['repository'] | length > 1 and not cluster_keepoff %}true{% else %}false{% endif %}
-
 {%- macro ats_proto() -%}
 http
 {%- if repo_keystore.cert_containers | default([]) | length > 0 -%}
@@ -82,13 +54,7 @@ transform.service.url={{ ats_proto() }}://{{ trouter_host }}:{{ ports_cfg.transf
 sfs.url={{ ats_proto() }}://{{ sfs_host }}:{{ ports_cfg.sfs.http }}
 {% endif %}
 
-messaging.broker.url=failover:({{ activemq_transport }}://{{ activemq_host }}:{{ ports_cfg.activemq[activemq_protocol] }})?timeout=3000
-messaging.broker.username={{ activemq_username }}
-messaging.broker.password={{ activemq_password }}
-
 dsync.service.uris={% if use_ssl | bool %}https{% else %}http{% endif %}://{% if fqdn_alfresco %}{{ fqdn_alfresco }}{% else %}{{ nginx_host }}{% endif %}:{% if use_ssl | bool %}{{ ports_cfg.nginx.https }}{% else %}{{ ports_cfg.nginx.http }}{% endif %}/alfresco
-
-aos.baseUrlOverwrite={% if use_ssl | bool %}https{% else %}http{% endif %}://{% if fqdn_alfresco %}{{ fqdn_alfresco }}{% else %}{{ nginx_host }}{% endif %}:{% if use_ssl | bool %}{{ ports_cfg.nginx.https }}{% else %}{{ ports_cfg.nginx.http }}{% endif %}/alfresco/aos
 
 # CSRF filter overrides
 {% import 'xorigins_macros.j2' as _xorigins_protection %}
@@ -116,7 +82,3 @@ cors.preflight.maxage={{ cors.preflight_maxage | default('10') }}
 {% else -%}
   false
 {% endif %}
-
-{% for prop in lookup('ansible.utils.to_paths', merged_repository_properties) | dict2items %}
-{{ prop.key }}={{ prop.value }}
-{% endfor %}

--- a/roles/sync/molecule/default/converge.yml
+++ b/roles/sync/molecule/default/converge.yml
@@ -1,24 +1,13 @@
 ---
 - name: Converge
   hosts: all
-  tasks:
-    - name: "Include postgres"
-      ansible.builtin.include_role:
-        name: "postgres"
-    - name: "Include repository"
-      ansible.builtin.include_role:
-        name: "repository"
-    - name: Flush Handlers
-      ansible.builtin.meta: flush_handlers
-    - name: "Include activemq"
-      ansible.builtin.include_role:
-        name: "activemq"
-    - name: "Include NGINX"
-      ansible.builtin.include_role:
-        name: "nginx"
-    - name: "Include sync"
-      ansible.builtin.include_role:
-        name: "sync"
+  roles:
+    - role: postgres
+    - role: activemq
+    - role: repository
+      repository_properties: "{{ global_properties }}"
+    - role: nginx
+    - role: sync
       vars:
         sync_environment:
           JAVA_OPTS:


### PR DESCRIPTION
Ref: OPSEXP-1280

2 ideas behind this refactoring: 
* Using a "master" template to generate properties computed/computable from the architecture/playbook on one side and another one to add properties from user provided files . Finally use `assemble`  to generate the final config file
* Moving as many properties as possible to a yaml datastructure in the repository group so that we can:
  * simplify the properties template to just render key/values
  * move some inventory dependent variables outside of the repository role 