### PR TITLE
Switch openssl stdin to standard password option

### DIFF
--- a/roles/java/tasks/keystores.yml
+++ b/roles/java/tasks/keystores.yml
@@ -42,7 +42,7 @@
           -cacerts
           -nokeys
           -out {{ certcp.results[loop_idx].checksum }}.pem
-        stdin: "{{ item.pass }}"
+          -password "pass:{{ item.pass }}"
     - name: Get certificate container aliases
       loop: "{{ java_keystore.cert_containers }}"
       loop_control:


### PR DESCRIPTION
When executing the v2.3.0 onward of the playbook, I always faced an issue where the playbook would hang forever on the `Export certificate chain` task.

When debugging the issue, all variables were properly populated and available in the task, but the `openssl` shell command would never complete:
```bash
[rocky@mop-alf-ce-tool ~]$ ps uxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
rocky      32241  0.0  0.1 163852  5704 ?        S    15:44   0:00 sshd: rocky@pts/1
rocky      32242  0.0  0.1 233920  3940 pts/1    Ss   15:44   0:00  \_ -bash
rocky      32273  0.0  0.1 268548  4048 pts/1    R+   15:44   0:00      \_ ps uxf
rocky      17174  0.0  0.1 164272  6636 ?        S    15:16   0:01 sshd: rocky@pts/0
rocky      31797  0.0  0.0 222856  3212 pts/0    Ss+  15:22   0:00  \_ /bin/sh -c /usr/libexec/platform-python /home/rocky/.ansible/tmp/ansible-tmp-1688044958.417771-4780-255436188732662/AnsiballZ_command.py && sleep 0
rocky      31820  0.0  0.5 333796 21352 pts/0    S+   15:22   0:00      \_ /usr/libexec/platform-python /home/rocky/.ansible/tmp/ansible-tmp-1688044958.417771-4780-255436188732662/AnsiballZ_command.py
rocky      31822  0.0  0.1  19304  4472 pts/0    S+   15:22   0:00          \_ openssl pkcs12 -in acbc3f37c95a520ec9f32385a84368c7e269abe9.p12 -cacerts -nokeys -out 59dd3b4e0a8ba3c75628ed9f20204ade25526ee9.pem
rocky      17165  0.0  0.2  89420  9404 ?        Ss   15:16   0:00 /usr/lib/systemd/systemd --user
rocky      17168  0.0  0.1 253080  5036 ?        S    15:16   0:00  \_ (sd-pam)
[rocky@mop-alf-ce-tool ~]$
[rocky@mop-alf-ce-tool ~]$ ps -ef | grep openssl
rocky      78360   78358  0 17:00 pts/1    00:00:00 openssl pkcs12 -in acbc3f37c95a520ec9f32385a84368c7e269abe9.p12 -cacerts -nokeys -out 59dd3b4e0a8ba3c75628ed9f20204ade25526ee9.pem
rocky      78381   33873  0 17:00 pts/0    00:00:00 grep --color=auto openssl
[rocky@mop-alf-ce-tool ~]$
[rocky@mop-alf-ce-tool ~]$ ll /tmp/ansible_artefacts/
total 249948
-rw-------. 1 rocky rocky         0 Jun 29 15:22 59dd3b4e0a8ba3c75628ed9f20204ade25526ee9.pem
-r--------. 1 rocky rocky      5873 Jun 29 15:22 acbc3f37c95a520ec9f32385a84368c7e269abe9.p12
-rw-r--r--. 1 rocky rocky  64418725 Jun 29 15:21 apache-activemq-5.16.6-bin.tar.gz
-rw-rw-r--. 1 rocky rocky 191514138 Jun 29 15:20 OpenJDK11U-jdk_x64_linux_17.0.3_7.tar.gz
[rocky@mop-alf-ce-tool ~]$
```

This shows that the openssl command is stuck. On the role associated to this task, it is currently using `stdin` from the `shell` module:
```yml
      ansible.builtin.shell:
        creates: "{{ certcp.results[loop_idx].checksum }}.pem"
        chdir: "{{ download_location }}"
        cmd: >
          openssl pkcs12
          -in "{{ item.path | basename }}"
          -cacerts
          -nokeys
          -out {{ certcp.results[loop_idx].checksum }}.pem
        stdin: "{{ item.pass }}"
```

From my point of view, this means that openssl isn't accepting the `stdin` parameter for the interactive prompt. It might work for standard input but most probably not for the interactive one.

As a solution, we could use the standard command line option `-password` from `openssl`. That's the purpose of this PR. I tested this change and I can see the playbook proceeding properly and the .pem file is being generated successfully (and the content is the same as if you try to execute the openssl command manually).


There are 3 occurrences of `stdin` currently and they are all inside the `roles/java/tasks/keystores.yml` file:
- name: Export certificate chain
- name: Get certificate container aliases
- name: Check if key exists

Somehow, the `stdin` doesn't work for the `name: Export certificate chain` (openssl) task but it does work for the `name: Get certificate container aliases` (keytool). I couldn't check the 3rd one since they are all "skipping" for me.