### PR TITLE
Hash inventory_hostname when used in path to avoid special characters

### DIFF
--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -75,11 +75,11 @@
     - name: Build keystore role argument
       ansible.builtin.set_fact:
         transformers_keystore:
-          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
+          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
           pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
           type: JCEKS
           cert_containers:
-            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
               pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
               add_to_trusted_ca: true
       when:
@@ -154,11 +154,11 @@
     - name: Build keystore role argument
       ansible.builtin.set_fact:
         repository_keystore:
-          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
+          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
           pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
           type: JCEKS
           cert_containers:
-            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
               pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
               add_to_trusted_ca: true
       when:
@@ -198,11 +198,11 @@
     - name: Build keystore role argument
       ansible.builtin.set_fact:
         trouter_keystore:
-          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
+          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
           pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
           type: JCEKS
           cert_containers:
-            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
               pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
               add_to_trusted_ca: true
       when:
@@ -239,11 +239,11 @@
     - name: Build keystore role argument
       ansible.builtin.set_fact:
         sfs_keystore:
-          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
+          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
           pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
           type: JCEKS
           cert_containers:
-            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
               pass: "{{ hostvars.localhost.certs_p12_passphrase }}"
               add_to_trusted_ca: true
       when:

--- a/playbooks/pki.yml
+++ b/playbooks/pki.yml
@@ -143,7 +143,7 @@
   tasks:
     - name: Check for provided host's PKCS12 container
       ansible.builtin.stat:
-        path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+        path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
       register: host_p12
       delegate_to: localhost
 
@@ -173,7 +173,7 @@
           no_log: true
           become: true
           community.crypto.openssl_privatekey:
-            path: /etc/pki/{{ inventory_hostname }}_{{ cert_key_type | default('') }}.key
+            path: /etc/pki/{{ inventory_hostname | ansible.builtin.hash }}_{{ cert_key_type | default('') }}.key
             mode: 0600
             size: "{{ cert_key_size | default(omit) }}"
             type: "{{ cert_key_type | default(omit) }}"
@@ -212,16 +212,16 @@
             ownca_privatekey_passphrase: "{{ secret_ca_passphrase }}"
             ownca_not_after: "{{ cert_days_valid_for | default(omit) }}"
             ownca_not_before: "+0s"
-            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.crt"
+            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.crt"
           delegate_to: localhost
 
         - name: Generate PKCS12 keystores
           community.crypto.openssl_pkcs12:
             action: export
-            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
+            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
             passphrase: "{{ p12_passphrase }}"
-            friendly_name: "{{ inventory_hostname }}"
+            friendly_name: "{{ inventory_hostname | ansible.builtin.hash }}"
             privatekey_content: "{{ srvkey.privatekey }}"
-            certificate_path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.crt"
+            certificate_path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.crt"
             ca_certificates: "{{ hostvars.localhost.ca_cert_path }}"
           delegate_to: localhost

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -21,7 +21,7 @@ repo_hosts: |
   | map('extract', hostvars)
   | json_query('[].
     {
-      inventory_name: inventory_hostname ,
+      inventory_name: inventory_hostname,
       local_addr: ansible_default_ipv4.address,
       cluster_keepoff: cluster_keepoff
     }')

--- a/roles/java/tasks/keystores.yml
+++ b/roles/java/tasks/keystores.yml
@@ -82,7 +82,7 @@
         pkcs12_path: >-
           {{ download_location }}/{{ item.path | basename }}
         pkcs12_password: "{{ item.pass }}"
-        cert_alias: "{{ inventory_hostname }}"
+        cert_alias: "{{ inventory_hostname | ansible.builtin.hash }}"
         keystore_type: "{{ java_keystore.type }}"
         keystore_path: "{{ java_keystore.path }}"
         keystore_pass: "{{ java_keystore.pass }}"


### PR DESCRIPTION
As discussed in issue #623, it would be useful to hash the `inventory_hostname` when it is used for path, to make sure that no special characters come into play and cause issues. In this PR, I changed the paths as well as the SSL Certificate alias because aliases have the same restrictions as hostnames.

Note 1: I didn't touch the `molecule` folders since this is your internal testing - let me know if you would like me to change them as well

Note 2: I didn't change `roles/common/tasks/check_upgrades.yml` as well, since the path `/tmp/{{ inventory_hostname }}/{{ ansible_installation_status_file }}` doesn't appear to have any other references anywhere at of this time. Therefore I would assume this was used in the past releases to store the status file but not anymore (`"{{ binaries_folder }}/.ansible_alfresco_components.status"`)

List of all inventory_hostname:
```bash
mop@DBI-LT-MOP2:alfresco-ansible-deployment$ grep -ri --color inventory_hostname *
docs/deployment-guide.md:* an `ansible_host` variable; if the host needs to be reached through an address that's different from the `inventory_hostname` (e.g. machine is only reachable through a bastion host or some sort of NAT).
molecule/multimachine/host_vars/repository_electron.yml:# variables for molecule tests - inventory_hostname: repository_electron
molecule/multimachine/host_vars/repository_proton.yml:# variables for molecule tests - inventory_hostname: repository_proton
molecule/multimachine/host_vars/repository_neutron.yml:# variables for molecule tests - inventory_hostname: repository_neutron
molecule/pki/verify.yml:        src: ../../configuration_files/pki/certificates/{{ inventory_hostname }}.p12
molecule/pki/verify.yml:        path: /tmp/{{ inventory_hostname }}.crt
molecule/pki/verify.yml:        src: /tmp/{{ inventory_hostname }}.crt
molecule/pki/verify.yml:          client_crt: /tmp/{{ inventory_hostname }}.crt
playbooks/pki.yml:        path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
playbooks/pki.yml:            path: /etc/pki/{{ inventory_hostname }}_{{ cert_key_type | default('') }}.key
playbooks/pki.yml:              - DNS:{{ inventory_hostname }}
playbooks/pki.yml:            common_name: "{{ ansible_fqdn | default(inventory_hostname) }}"
playbooks/pki.yml:            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.crt"
playbooks/pki.yml:            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
playbooks/pki.yml:            friendly_name: "{{ inventory_hostname }}"
playbooks/pki.yml:            certificate_path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.crt"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname }}.p12"
roles/repository/templates/share-config-custom.xml.j2:	 <referer>{{ _xorigins_protection.compute(inventory_hostname, 'referer', csrf.urls)}}</referer>
roles/repository/templates/share-config-custom.xml.j2:	 <origin>{{ _xorigins_protection.compute(inventory_hostname, 'origin', csrf.urls)}}</origin>
roles/repository/templates/alfresco-global.properties.j2:  csrf.filter.referer={{ _xorigins_protection.compute(inventory_hostname, 'referer', csrf.urls) }}
roles/repository/templates/alfresco-global.properties.j2:  csrf.filter.origin={{ _xorigins_protection.compute(inventory_hostname, 'origin', csrf.urls) }}
roles/repository/templates/alfresco-global.properties.j2:  cors.allowed.origins={{ _xorigins_protection.compute(inventory_hostname, 'origin', cors.urls) }}
roles/java/tasks/keystores.yml:        cert_alias: "{{ inventory_hostname }}"
roles/java/molecule/default/tests/test_java.py:    hostname = host.ansible.get_variables()["inventory_hostname"]
roles/java/molecule/default/converge.yml:            - path: "{{ inventory_hostname }}.p12"
roles/search/tasks/replication.yml:          {{ 'slave' if inventory_hostname == search_master else 'master' }}
roles/search/tasks/replication.yml:          {{ '20' if inventory_hostname == search_master else '5' }}
roles/search/tasks/replication.yml:      when: inventory_hostname == ansible_play_hosts_all | first
roles/search/tasks/replication.yml:      when: inventory_hostname != search_master
roles/search/tasks/replication.yml:          {{ master_xml if inventory_hostname == search_master else slave_xml }}
roles/search/templates/solrcore.properties.j2:{% if search_topology == 'replication' and inventory_hostname != search_master %}
roles/search/templates/solrcore.properties.j2:{% if search_topology == 'replication' and inventory_hostname == search_master %}
roles/helper_modules/tasks/check_port.yml:    - name: "Verify if {{ inventory_hostname }} can reach {{ delegate_target }}:{{ checked_port }}"
roles/common/tasks/check_upgrades.yml:    file: /tmp/{{ inventory_hostname }}/{{ ansible_installation_status_file }}
roles/common/defaults/main.yml:      inventory_name: inventory_hostname,
roles/postgres/molecule/default/tests/test_postgres.py:    pghost = host.ansible.get_variables()['inventory_hostname']
mop@DBI-LT-MOP2:alfresco-ansible-deployment$
```

List of inventory_hostname that are hashed:
```bash
mop@DBI-LT-MOP2:alfresco-ansible-deployment$ grep -ri --color inventory_hostname * | grep ansible.builtin.hash
playbooks/pki.yml:        path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
playbooks/pki.yml:            path: /etc/pki/{{ inventory_hostname | ansible.builtin.hash }}_{{ cert_key_type | default('') }}.key
playbooks/pki.yml:            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.crt"
playbooks/pki.yml:            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
playbooks/pki.yml:            friendly_name: "{{ inventory_hostname | ansible.builtin.hash }}"
playbooks/pki.yml:            certificate_path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.crt"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
playbooks/acs.yml:          path: "{{ config_folder }}/pki/{{ inventory_hostname | ansible.builtin.hash }}.keystore"
playbooks/acs.yml:            - path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | ansible.builtin.hash }}.p12"
roles/java/tasks/keystores.yml:        cert_alias: "{{ inventory_hostname | ansible.builtin.hash }}"
mop@DBI-LT-MOP2:alfresco-ansible-deployment$
```

List of inventory_hostname that aren't touched as of now:
```bash
mop@DBI-LT-MOP2:alfresco-ansible-deployment$ grep -ri --color inventory_hostname * | grep -v ansible.builtin.hash
docs/deployment-guide.md:* an `ansible_host` variable; if the host needs to be reached through an address that's different from the `inventory_hostname` (e.g. machine is only reachable through a bastion host or some sort of NAT).
molecule/multimachine/host_vars/repository_electron.yml:# variables for molecule tests - inventory_hostname: repository_electron
molecule/multimachine/host_vars/repository_proton.yml:# variables for molecule tests - inventory_hostname: repository_proton
molecule/multimachine/host_vars/repository_neutron.yml:# variables for molecule tests - inventory_hostname: repository_neutron
molecule/pki/verify.yml:        src: ../../configuration_files/pki/certificates/{{ inventory_hostname }}.p12
molecule/pki/verify.yml:        path: /tmp/{{ inventory_hostname }}.crt
molecule/pki/verify.yml:        src: /tmp/{{ inventory_hostname }}.crt
molecule/pki/verify.yml:          client_crt: /tmp/{{ inventory_hostname }}.crt
playbooks/pki.yml:              - DNS:{{ inventory_hostname }}
playbooks/pki.yml:            common_name: "{{ ansible_fqdn | default(inventory_hostname) }}"
roles/repository/templates/share-config-custom.xml.j2:	 <referer>{{ _xorigins_protection.compute(inventory_hostname, 'referer', csrf.urls)}}</referer>
roles/repository/templates/share-config-custom.xml.j2:	 <origin>{{ _xorigins_protection.compute(inventory_hostname, 'origin', csrf.urls)}}</origin>
roles/repository/templates/alfresco-global.properties.j2:  csrf.filter.referer={{ _xorigins_protection.compute(inventory_hostname, 'referer', csrf.urls) }}
roles/repository/templates/alfresco-global.properties.j2:  csrf.filter.origin={{ _xorigins_protection.compute(inventory_hostname, 'origin', csrf.urls) }}
roles/repository/templates/alfresco-global.properties.j2:  cors.allowed.origins={{ _xorigins_protection.compute(inventory_hostname, 'origin', cors.urls) }}
roles/java/molecule/default/tests/test_java.py:    hostname = host.ansible.get_variables()["inventory_hostname"]
roles/java/molecule/default/converge.yml:            - path: "{{ inventory_hostname }}.p12"
roles/search/tasks/replication.yml:          {{ 'slave' if inventory_hostname == search_master else 'master' }}
roles/search/tasks/replication.yml:          {{ '20' if inventory_hostname == search_master else '5' }}
roles/search/tasks/replication.yml:      when: inventory_hostname == ansible_play_hosts_all | first
roles/search/tasks/replication.yml:      when: inventory_hostname != search_master
roles/search/tasks/replication.yml:          {{ master_xml if inventory_hostname == search_master else slave_xml }}
roles/search/templates/solrcore.properties.j2:{% if search_topology == 'replication' and inventory_hostname != search_master %}
roles/search/templates/solrcore.properties.j2:{% if search_topology == 'replication' and inventory_hostname == search_master %}
roles/helper_modules/tasks/check_port.yml:    - name: "Verify if {{ inventory_hostname }} can reach {{ delegate_target }}:{{ checked_port }}"
roles/common/tasks/check_upgrades.yml:    file: /tmp/{{ inventory_hostname }}/{{ ansible_installation_status_file }}
roles/common/defaults/main.yml:      inventory_name: inventory_hostname,
roles/postgres/molecule/default/tests/test_postgres.py:    pghost = host.ansible.get_variables()['inventory_hostname']
mop@DBI-LT-MOP2:alfresco-ansible-deployment$
```