### PR TITLE
Wait for mounts before starting components + add auto-restart on failure

### DIFF
--- a/roles/activemq/templates/activemq.service.j2
+++ b/roles/activemq/templates/activemq.service.j2
@@ -1,12 +1,14 @@
 [Unit]
 Description=Apache ActiveMQ - Alfresco instance
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=forking
 User={{ username }}
 ExecStart={{ binaries_folder }}/activemq.sh start
 ExecStop={{ binaries_folder }}/activemq.sh stop
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/search/templates/alfresco-search.service
+++ b/roles/search/templates/alfresco-search.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Alfresco Search Service
-After=syslog.target network.target remote-fs.target nss-lookup.target
+After=syslog.target network.target local-fs.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking
@@ -12,6 +12,7 @@ ExecStart={{ binaries_dir }}/solr.sh start -a "-Dcreate.alfresco.defaults={{ sea
 ExecReload={{ binaries_dir }}/solr.sh restart
 ExecStop={{ binaries_dir }}/solr.sh stop
 Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/search_enterprise/templates/elasticsearch-connector-reindex.service.j2
+++ b/roles/search_enterprise/templates/elasticsearch-connector-reindex.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Alfresco Enterprise Search - Reindex job
-After=syslog.target network.target remote-fs.target nss-lookup.target
+After=syslog.target network.target local-fs.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=oneshot

--- a/roles/search_enterprise/templates/elasticsearch-connector.service.j2
+++ b/roles/search_enterprise/templates/elasticsearch-connector.service.j2
@@ -1,6 +1,6 @@
 [Unit]
 Description=Alfresco Enterprise Search - All in one Service
-After=syslog.target network.target remote-fs.target nss-lookup.target
+After=syslog.target network.target local-fs.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=simple

--- a/roles/sfs/templates/alfresco-shared-fs.service
+++ b/roles/sfs/templates/alfresco-shared-fs.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Alfresco Shared File Store
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=simple
 User={{ username }}
 ExecStart={{ binaries_folder }}/ats-shared-fs.sh
 WorkingDirectory={{ ats_home }}
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/sync/templates/alfresco-sync.service
+++ b/roles/sync/templates/alfresco-sync.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Alfresco Sync Service
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=forking
 User={{ username }}
 ExecStart={{ binaries_folder }}/syncservice.sh start
 ExecStop={{ binaries_folder }}/syncservice.sh stop
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/tomcat/templates/alfresco-content.service
+++ b/roles/tomcat/templates/alfresco-content.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Alfresco Content Services
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=forking
 User={{ username }}
 ExecStart={{ binaries_folder }}/tomcat.sh start
 ExecStop={{ binaries_folder }}/tomcat.sh stop
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/transformers/templates/alfresco-tengine-aio.service
+++ b/roles/transformers/templates/alfresco-tengine-aio.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Alfresco Transform Service - AIO Transform Engine
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=simple
 User={{ username }}
 ExecStart={{ binaries_folder }}/ats-ate-aio.sh
 WorkingDirectory={{ ats_home }}
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/trouter/templates/alfresco-transform-router.service
+++ b/roles/trouter/templates/alfresco-transform-router.service
@@ -1,12 +1,14 @@
 [Unit]
 Description=Alfresco Transform Router
-After=syslog.socket network.target
+After=syslog.socket network.target local-fs.target remote-fs.target
 
 [Service]
 Type=simple
 User={{ username }}
 ExecStart={{ binaries_folder }}/ats-atr.sh
 WorkingDirectory={{ ats_home }}
+Restart=on-failure
+RestartSec=60
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As a best practice, the 4 standard paths mentioned [in the doc](https://github.com/Alfresco/alfresco-ansible-deployment/blob/master/docs/deployment-guide.md#folder-structure) will most probably be using a dedicated mount/filesystem.

At installation, it is fine since the filesystems should already be mounted (if some needs to be used). However, in case of OS restart, the different services are currently configured to be executed `After=syslog.socket network.target`. With this configuration of the service, it can happen that the OS tries to start the Alfresco components before the filesystem is even available. In such cases, it would obviously fail (`status=203/EXEC`) and therefore not startup the component at all. Example of logs showing that the filesystem for /opt/alfresco/ is mounted after ActiveMQ tries to startup:
```bash
[root@mop-alf-ce-tool ~]# grep After /etc/systemd/system/activemq.service
After=syslog.socket network.target
[root@mop-alf-ce-tool ~]#
[root@mop-alf-ce-tool ~]# journalctl -xe | grep -E "activemq|opt-alfresco"
-- Subject: Unit activemq.service has begun start-up
-- Unit activemq.service has begun starting up.
Jul 12 09:23:41 mop-alf-ce-tool systemd[904]: activemq.service: Failed to execute command: No such file or directory
Jul 12 09:23:41 mop-alf-ce-tool systemd[904]: activemq.service: Failed at step EXEC spawning /opt/alfresco/activemq.sh: No such file or directory
-- Subject: Process /opt/alfresco/activemq.sh could not be executed
-- The process /opt/alfresco/activemq.sh could not be executed and failed.
Jul 12 09:23:41 mop-alf-ce-tool systemd[1]: activemq.service: Control process exited, code=exited status=203
Jul 12 09:23:41 mop-alf-ce-tool systemd[1]: activemq.service: Failed with result 'exit-code'.
-- The unit activemq.service has entered the 'failed' state with result 'exit-code'.
-- Subject: Unit activemq.service has failed
-- Unit activemq.service has failed.
-- Subject: Unit opt-alfresco.mount has begun start-up
-- Unit opt-alfresco.mount has begun starting up.
[root@mop-alf-ce-tool ~]#
```

Since the filesystem is mounted after ActiveMQ tries to start, it fails with `No such file or directory` and because there is no restart by default, then ActiveMQ isn't running. I faced this issue on both `activemq.service` as well as `alfresco-content.service` but it can happen on most of them, depending on where they are installed and the order the OS decides for the startup.

Therefore, I believe it would be better to make sure that the local and remote filesystems are all properly mounted before trying to startup the different Alfresco components. This can be achieved by adding `local-fs.target remote-fs.target` in the definition of the different services (`After=syslog.socket network.target local-fs.target remote-fs.target`).

As part of this PR, I also added the automatic restart of the processes `on-failure` (c.f. [definition of the systemd service](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=)). This is more of a debatable option, since the OS will try to restart most of the components even if you are shutting them down manually (without using the `systemctl stop xxx` command) on purpose because the `SuccessExitStatus` is usually not 0 (and I didn't configure it). This means that people should only use the service to stop/start the different components (which, from my point of view, should always be how it's done...). It adds recovery in case of OOM or other kills, which is a necessary thing from my point of view.

Please let me know if you would like to change slightly the configuration and/or remove the restart option I added.