### PR TITLE
OPSEXP-2176 Allow repo_db_url to override search enterprise reindex configuration

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -12,9 +12,9 @@ collections:
     version: 2.10.0
   # molecule ec2 tests
   - name: amazon.aws
-    version: 5.3.0
+    version: 6.3.0
   - name: community.aws
-    version: 5.3.0
+    version: 6.3.0
   # molecule roles tests
   - name: community.docker
     version: 2.1.1

--- a/roles/search_enterprise/templates/elasticsearch-connector-reindex.service.j2
+++ b/roles/search_enterprise/templates/elasticsearch-connector-reindex.service.j2
@@ -9,7 +9,7 @@ User={{ username }}
 
 {% include "elasticsearch-cfg.j2" %}
 
-Environment=SPRING_DATASOURCE_URL=jdbc:postgresql://{{ db_host }}:{{ ports_cfg.postgres.sql }}/{{ repo_db_name }}
+Environment=SPRING_DATASOURCE_URL={{ repo_db_url if repo_db_url else 'jdbc:postgresql://' + db_host + ':' + ports_cfg.postgres.sql | string + '/' + repo_db_name }}
 Environment=SPRING_DATASOURCE_USERNAME={{ repo_db_username }}
 Environment=SPRING_DATASOURCE_PASSWORD={{ repo_db_password }}
 


### PR DESCRIPTION
Ref: OPSEXP-2176