### PR TITLE
OPSEXP-2304 Fixup secret presence for activemq, elasticsearch and identity

### DIFF
--- a/playbooks/secrets.yml
+++ b/playbooks/secrets.yml
@@ -62,21 +62,21 @@
         that: activemq_password is defined and activemq_password | length > 0
         msg: "activemq_password must have been already set at this point"
         quiet: true
-      when: groups.external_activemq | default(False)
+      when: ((groups.activemq | default([])) + (groups.external_activemq | default([]))) | length > 0
 
     - name: Ensure elasticsearch_password is set when required
       ansible.builtin.assert:
         that: elasticsearch_password is defined and elasticsearch_password | length > 0
         msg: "elasticsearch_password must have been already set at this point"
         quiet: true
-      when: groups.external_elasticsearch | default(False)
+      when: ((groups.elasticsearch | default([])) + (groups.external_elasticsearch | default([]))) | length > 0
 
     - name: Ensure identity_admin_password is set when required
       ansible.builtin.assert:
         that: identity_admin_password is defined and identity_admin_password | length > 0
         msg: "identity_admin_password must have been already set at this point"
         quiet: true
-      when: groups.external_identity | default(False)
+      when: ((groups.identity | default([])) + (groups.external_identity | default([]))) | length > 0
 
 - name: Set secrets for Search auth
   hosts: repository:search


### PR DESCRIPTION
Was not taking in account the non-external group, caused by copy-pasting the activemq task which initially doesn't had credentials support (but now has).

Ref: OPSEXP-2304