### PR TITLE
OPSEXP-2331 Fix flaky failure in search role

### DIFF
--- a/roles/search/tasks/replication.yml
+++ b/roles/search/tasks/replication.yml
@@ -7,10 +7,11 @@
   block:
     - name: Wait for core creation to complete
       ansible.builtin.wait_for:
-        path: "{{ config_dir }}/solrhome/{{ search_cores | first }}/conf/solrconfig.xml"
+        path: "{{ config_dir }}/solrhome/{{ item }}/conf/solrconfig.xml"
       timeout: 30
       delay: 3
       retries: 3
+      loop: "{{ search_cores }}"
 
     - name: Make sure host do not assume a previous role
       vars:


### PR DESCRIPTION
Ref: OPSEXP-2331

```
TASK [../roles/search : Wait for core creation to complete] ********************
ok: [test-gionn-repo2]
ok: [test-gionn-repo1]

TASK [../roles/search : Make sure host do not assume a previous role] **********
ok: [test-gionn-repo2] => (item=alfresco)
ok: [test-gionn-repo1] => (item=alfresco)
ok: [test-gionn-repo2] => (item=archive)
failed: [test-gionn-repo1] (item=archive) => {"ansible_loop_var": "item", "changed": false, "item": "archive", "msg": "The target XML source '/etc/opt/alfresco/search-services/solrhome/archive/conf/solrconfig.xml' does not exist."}
```