### PR TITLE
Allow access to Control Center for Community

### DIFF
--- a/roles/nginx/templates/alfresco_proxy.include.j2
+++ b/roles/nginx/templates/alfresco_proxy.include.j2
@@ -49,6 +49,11 @@
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
+    location /control-center/ {
+        proxy_pass http://{{ acc_host }}:8881/;
+        include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
+    }
+
 {% if acs.edition == "Enterprise" %}
     location /syncservice/ {
         proxy_pass http://{{ sync_host }}:{{ ports_cfg.sync.http }}/alfresco/;
@@ -57,11 +62,6 @@
 
     location /workspace/ {
         proxy_pass http://{{ adw_host }}:8880/;
-        include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
-    }
-
-    location /control-center/ {
-        proxy_pass http://{{ acc_host }}:8881/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 {% endif %}

--- a/roles/nginx/templates/alfresco_proxy.include.j2
+++ b/roles/nginx/templates/alfresco_proxy.include.j2
@@ -44,24 +44,32 @@
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
+{% if groups['identity'] | default([]) | length != 0 %}
     location /auth/ {
         proxy_pass http://{{ identity_host }}:{{ ports_cfg.identity.http }}/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
+{% endif %}
+{% if groups['acc'] | default([]) | length != 0 %}
     location /control-center/ {
         proxy_pass http://{{ acc_host }}:8881/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
+{% endif %}
 {% if acs.edition == "Enterprise" %}
+{% if groups['syncservice'] | default([]) | length != 0 %}
     location /syncservice/ {
         proxy_pass http://{{ sync_host }}:{{ ports_cfg.sync.http }}/alfresco/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
+{% endif %}
+{% if groups['adw'] | default([]) | length != 0 %}
     location /workspace/ {
         proxy_pass http://{{ adw_host }}:8880/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
+{% endif %}
 {% endif %}

--- a/roles/nginx/templates/alfresco_proxy.include.j2
+++ b/roles/nginx/templates/alfresco_proxy.include.j2
@@ -44,14 +44,14 @@
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
-{% if groups['identity'] | default([]) | length != 0 %}
+{% if groups['identity'] | default([]) | length > 0 %}
     location /auth/ {
         proxy_pass http://{{ identity_host }}:{{ ports_cfg.identity.http }}/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
 {% endif %}
-{% if groups['acc'] | default([]) | length != 0 %}
+{% if groups['acc'] | default([]) | length > 0 %}
     location /control-center/ {
         proxy_pass http://{{ acc_host }}:8881/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
@@ -59,14 +59,14 @@
 
 {% endif %}
 {% if acs.edition == "Enterprise" %}
-{% if groups['syncservice'] | default([]) | length != 0 %}
+{% if groups['syncservice'] | default([]) | length > 0 %}
     location /syncservice/ {
         proxy_pass http://{{ sync_host }}:{{ ports_cfg.sync.http }}/alfresco/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
 {% endif %}
-{% if groups['adw'] | default([]) | length != 0 %}
+{% if groups['adw'] | default([]) | length > 0 %}
     location /workspace/ {
         proxy_pass http://{{ adw_host }}:8880/;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;


### PR DESCRIPTION
Alfresco Control Center is installed even for Community but it is only accessible from localhost:8881 because of Security Filters and other things. So it is necessary to add the proxy from the main 80/443 ports into the server hosting this ADF-based application so that it can be accessed.

For example, if you try to install a simple Community version, with the current template, you will have a /auth/ URL that will fail if there is no Identity (KeyCloak) component and you won't have access to ACC.

I believe it would be better to add conditions for Identity URL (a condition like `identity` group not empty?) and to remove the condition for ACC (this PR or even better, have a condition like `acc` group not empty?).