### PR TITLE
Create pki subfolders for inventory hosts with slash

### DIFF
--- a/playbooks/pki.yml
+++ b/playbooks/pki.yml
@@ -209,6 +209,7 @@
           ansible.builtin.file:
             path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | dirname }}"
             state: directory
+            mode: "0750"
           delegate_to: localhost
 
         - name: Sign certificate with our CA

--- a/playbooks/pki.yml
+++ b/playbooks/pki.yml
@@ -171,13 +171,15 @@
             state: present
 
         - name: Create private key for new certificate
+          vars:
+            key_type: "{{ cert_key_type | default('RSA') }}"
           no_log: true
           become: true
           community.crypto.openssl_privatekey:
-            path: /etc/pki/private/{{ inventory_hostname | basename }}_{{ cert_key_type | default('') }}.key
+            path: /etc/pki/private/{{ inventory_hostname | basename }}_{{ key_type }}.key
             mode: 0600
             size: "{{ cert_key_size | default(omit) }}"
-            type: "{{ cert_key_type | default(omit) }}"
+            type: "{{ key_type }}"
             return_content: true
           register: srvkey
 

--- a/playbooks/pki.yml
+++ b/playbooks/pki.yml
@@ -158,9 +158,9 @@
             state: directory
             mode: "{{ item.mode | default(omit) }}"
           loop:
-            - name: /etc/pki/{{ inventory_hostname | dirname }}
+            - name: /etc/pki
             - name: /etc/pki/private
-              mode: "0600"
+              mode: "0700"
 
         - name: Install PKI required packages
           become: true
@@ -174,7 +174,7 @@
           no_log: true
           become: true
           community.crypto.openssl_privatekey:
-            path: /etc/pki/{{ inventory_hostname }}_{{ cert_key_type | default('') }}.key
+            path: /etc/pki/private/{{ inventory_hostname | basename }}_{{ cert_key_type | default('') }}.key
             mode: 0600
             size: "{{ cert_key_size | default(omit) }}"
             type: "{{ cert_key_type | default(omit) }}"

--- a/playbooks/pki.yml
+++ b/playbooks/pki.yml
@@ -13,8 +13,8 @@
           - p12_passphrase
           - secret_ca_passphrase
         fail_msg: |
-          this playbook do not generate passwords. You must generate then and
-          store them securely, and pass them as varaiables for the plybook to
+          this playbook do not generate passwords. You must generate them and
+          store them securely, and pass them as varaiables for the playbook to
           generate private keys, certificates and containers.
           expected varaibles are p12_passphrase, secret_ca_passphrase and
           key_password
@@ -30,6 +30,7 @@
         - name: certificates
         - name: private
           mode: "0700"
+
     - name: Check for provided CA signing certificate
       ansible.builtin.stat:
         path: "{{ ca_file }}"
@@ -80,16 +81,16 @@
               - ca_cert_valid.valid_at.tomorrow
               - ca_key_valid.can_parse_key
             fail_msg: |
-              We could not pearse your provided CA! Please check the files:
+              We could not parse your provided CA! Please check the files
               {{ ca_cert_stat.stat.path }} & {{ ca_key_stat.stat.path }}
-              and its passphrase.
+              and their passphrases.
 
         - name: Set CA variables
           ansible.builtin.set_fact:
             ca_cert_path: "{{ ca_cert_stat.stat.path }}"
             ca_key_path: "{{ ca_key_stat.stat.path }}"
 
-    - name: Generate out own CA
+    - name: Generate our own CA
       vars:
         ownca_key_path: "{{ actual_pki_dir }}/private/alfresco_platform_CA.key"
         ownca_cert_path: "{{ actual_pki_dir }}/ca/alfresco_platform_CA.crt"
@@ -157,7 +158,7 @@
             state: directory
             mode: "{{ item.mode | default(omit) }}"
           loop:
-            - name: /etc/pki
+            - name: /etc/pki/{{ inventory_hostname | dirname }}
             - name: /etc/pki/private
               mode: "0600"
 
@@ -201,6 +202,12 @@
             subject_alt_name: "{{ alt_names | unique }}"
           register: csr
           changed_when: false
+
+        - name: Create localhost PKI directory
+          ansible.builtin.file:
+            path: "{{ hostvars.localhost.pki_dir }}/certificates/{{ inventory_hostname | dirname }}"
+            state: directory
+          delegate_to: localhost
 
         - name: Sign certificate with our CA
           no_log: true


### PR DESCRIPTION
As discussed in issue #623 and then PR #635, I'm creating another PR (the 635 was too far behind, too many changes could come into conflict) that is for subfolder creation in the PKI playbook.

This updated version will create the needed subfolders on both the remote server and the Ansible Control Node as needed (and also fixing a few typos). In the end, it's only updating the line 161 to include any possible directory coming from the `inventory_hostname` variable. The `| dirname` takes care of everything so even if there is no `/` in the name, then the /etc/pki folder gets created (if it doesn't exist yet). And if it does contain one, then it will create both the /etc/pki and any subfolder needed.

I also added a task to create the folder on the Control Node around the end of the file, since this is also needed and I don't think I can put it at the beginning of the file because I don't know all the `inventory_hostname` for all hosts at this point in time.

Note/Question: what is the use of creating the `- name: /etc/pki/private` folder on the target server (line 162/163)? From what I can see, this folder is never used on the target server, is it?

Thanks!
Morgan