### PR TITLE
Remove not really needed constraints in workflows

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -85,8 +85,6 @@ jobs:
   docker_integration:
     name: Test ${{ matrix.scenario.name }} scenario on ${{ matrix.molecule_distro.image }}
     if: github.actor != 'dependabot[bot]'
-    needs:
-      - docker
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -81,7 +81,6 @@ jobs:
 
   docker_integration:
     name: Test ${{ matrix.scenario.name }} scenario on ${{ matrix.molecule_distro.image }}
-    if: github.actor != 'dependabot[bot]'
     needs:
       - docker
     strategy:


### PR DESCRIPTION
* docker_integration waiting for docker in community is just making overall execution time longer
* docker_integration in enterprise can run on dependabot (nexus and github secrets are available)