### PR TITLE
Fix source path for JDBC driver on localhost

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -279,7 +279,7 @@
 
     - name: Copy db_connector_repo to {{ tomcat_config_dir }}/lib/ folder
       ansible.builtin.copy:
-        src: "{{ inventory_dir }}/configuration_files/db_connector_repo/"
+        src: "{{ role_path }}/../../configuration_files/db_connector_repo/"
         dest: "{{ tomcat_config_dir }}/lib/"
         owner: "{{ username }}"
         group: "{{ group_name }}"

--- a/roles/sync/tasks/main.yml
+++ b/roles/sync/tasks/main.yml
@@ -63,7 +63,7 @@
 
     - name: Copy db_connector to {{ sync_home }}/service-sync/connectors folder
       ansible.builtin.copy:
-        src: "{{ inventory_dir }}/configuration_files/db_connector_sync/"
+        src: "{{ role_path }}/../../configuration_files/db_connector_sync/"
         dest: "{{ sync_home }}/service-sync/connectors/"
         owner: "{{ username }}"
         group: "{{ group_name }}"


### PR DESCRIPTION
When not using the internal DB but instead using the external one, the JDBC driver is supposed to be provided inside the `configuration_files/db_connector_repo` and/or `configuration_files/db_connector_sync`. However, the roles for the repository and sync are currently using a source value using `inventory_dir`, which doesn't exist apparently. It's the only 2 path using that:

```bash
$ grep -ri '/configuration_files/' playbooks roles | grep -v molecule
playbooks/pki.yml:    actual_pki_dir: "{{ pki_dir | default('../configuration_files/pki') }}"
roles/repository/tasks/main.yml:        src: "{{ inventory_dir }}/configuration_files/db_connector_repo/"
roles/repository/tasks/main.yml:        src: "{{ role_path }}/../../configuration_files/licenses/"
roles/repository/tasks/main.yml:        src: "{{ role_path }}/../../configuration_files/keystores/"
roles/nginx/tasks/vhosts.yml:        src: "{{ role_path }}/../../configuration_files/ssl_certificates/{{ item.cert_key }}"
roles/nginx/tasks/vhosts.yml:        src: "{{ role_path }}/../../configuration_files/ssl_certificates/{{ item.cert_crt }}"
roles/sync/tasks/main.yml:        src: "{{ inventory_dir }}/configuration_files/db_connector_sync/"
$
$ grep -ri inventory_dir *
roles/repository/tasks/main.yml:        src: "{{ inventory_dir }}/configuration_files/db_connector_repo/"
roles/sync/tasks/main.yml:        src: "{{ inventory_dir }}/configuration_files/db_connector_sync/"
$
```

As mentioned in #716, I aligned the path in this PR with the other places that used the `configuration_files` folder. Tested successfully, the deployment is successful and Alfresco is working properly as well.