### PR TITLE
OPSEXP-2446 Drop docker collection and bump aws collection

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,6 +13,11 @@ collections:
     version: 2.10.0
   - name: middleware_automation.keycloak
     version: 2.0.1
+  # molecule ec2 tests
+  - name: amazon.aws
+    version: 7.2.0
+  - name: community.aws
+    version: 7.1.0
 
 roles:
   - name: buluma.elastic_repo

--- a/requirements.yml
+++ b/requirements.yml
@@ -13,14 +13,6 @@ collections:
     version: 2.10.0
   - name: middleware_automation.keycloak
     version: 2.0.1
-  # molecule ec2 tests
-  - name: amazon.aws
-    version: 6.5.1
-  - name: community.aws
-    version: 6.3.0
-  # molecule roles tests
-  - name: community.docker
-    version: 2.1.1
 
 roles:
   - name: buluma.elastic_repo


### PR DESCRIPTION
* Docker collection is managed by molecule plugin
* Bump EC2 collection

Ref: OPSEXP-2446