### PR TITLE
Update .gitignore for db_connector_sync config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # project specifics
 configuration_files/db_connector_repo/
+configuration_files/db_connector_sync/
 configuration_files/ssl_certificates/
 configuration_files/keystores/
 configuration_files/pki/


### PR DESCRIPTION
Hello team,

A very small PR to ignore the folder `configuration_files/db_connector_sync/`, as it was done for other configuration folders, to avoid pushing non-expected files.

Cheers,
Morgan