### PR TITLE
OPSEXP-2505 Bump postgresql jdbc connector to fix CVE-2024-1597

### DIFF
--- a/7.0.N-extra-vars.yml
+++ b/7.0.N-extra-vars.yml
@@ -56,7 +56,7 @@ sync:
 
 # this overwrites (and not merge) the same structure in group_vars/all.yml
 dependencies_version:
-  postgresql_connector: 42.2.18
+  postgresql_connector: 42.6.1
   postgres_major_version: 13
   activemq: 5.16.7
   java: 11.0.15

--- a/7.1.N-extra-vars.yml
+++ b/7.1.N-extra-vars.yml
@@ -50,7 +50,7 @@ sync:
   version: 3.11.1
 # this overwrites (and not merge) the same structure in group_vars/all.yml
 dependencies_version:
-  postgresql_connector: 42.2.19
+  postgresql_connector: 42.6.1
   postgres_major_version: 13
   activemq: 5.16.7
   java: 11.0.15

--- a/7.2.N-extra-vars.yml
+++ b/7.2.N-extra-vars.yml
@@ -48,7 +48,7 @@ sync:
   repository: "{{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x"
   version: 3.11.1
 dependencies_version:
-  postgresql_connector: 42.2.19
+  postgresql_connector: 42.6.1
   postgres_major_version: 13
   activemq: 5.16.7
   java: 11.0.15

--- a/7.3.N-extra-vars.yml
+++ b/7.3.N-extra-vars.yml
@@ -48,7 +48,7 @@ sync:
   repository: "{{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x"
   version: 3.11.1
 dependencies_version:
-  postgresql_connector: 42.2.19
+  postgresql_connector: 42.6.1
   postgres_major_version: 13
   activemq: 5.17.6
   java: 11.0.15

--- a/7.4.N-extra-vars.yml
+++ b/7.4.N-extra-vars.yml
@@ -56,7 +56,7 @@ acc:
   repository: "{{ nexus_repository.releases }}"
   version: 8.0.0
 dependencies_version:
-  postgresql_connector: 42.2.19
+  postgresql_connector: 42.6.1
   postgres_major_version: 14
   activemq: 5.17.6
   java: 17.0.3

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -185,7 +185,7 @@ use_custom_keystores: false
 # common dependencies should be updated also in *-extra-vars.yml as well thanks
 # to default ansible merging behaviour
 dependencies_version:
-  postgresql_connector: 42.2.19
+  postgresql_connector: 42.6.1
   postgres_major_version: 14
   activemq: 5.18.3
   java: 17.0.9


### PR DESCRIPTION
Ref: OPSEXP-2505

I see [different versions](https://jdbc.postgresql.org/download/#latest-versions) are maintained mainly depending on java version so I bumped all of them