### PR TITLE
Skip enterprise workflow when nexus secrets are not available

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -25,10 +25,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-nexus-secrets:
+    name: Ensure required nexus secrets are available
+    runs-on: ubuntu-latest
+    outputs:
+      secrets-available: ${{ steps.check-secrets.outputs.secrets-available }}
+    steps:
+      - name: Check secrets
+        id: check-secrets
+        run: | # pragma: allowlist secret
+          if [ -z "${{ secrets.nexus_username }}" ] || [-z "${{ secrets.nexus_password }}"]; then
+            echo "nexus_username or nexus_password is missing"
+            echo "secrets-available=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "secrets-available=true" >> $GITHUB_OUTPUT
   docker:
     name: Test ${{ matrix.role.name }} role on ${{ matrix.molecule_distro.image }}
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'Alfresco'
+    needs: check-nexus-secrets
+    if: needs.check-nexus-secrets.outputs.secrets-available == 'true'
     outputs:
       dtas_version: ${{ steps.jobvars.outputs.dtas_version }}
     strategy:


### PR DESCRIPTION
Explicit check on nexus secrets availability to decide if run the tests or not (enterprise cannot work without nexus credentials)