### PR TITLE
OPSEXP-2603 Fix theme javascript inclusion

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,8 @@ logo: "resources/hyland-alfresco-logos.png"
 favicon_ico: "favicon.ico"
 
 defaults:
+  # apply the default layout to all markdown pages
   - scope:
-      path: "" # an empty string here means all files in the project
+      path: "*.md"
     values:
       layout: "default"


### PR DESCRIPTION
I noticed only now that the hamburger menu in mobile mode was not working anymore and a js console error was raising up.

Ref: OPSEXP-2603