### PR TITLE
OPSEXP-2627: bump components for Fornax release

### DIFF
--- a/7.1.N-extra-vars.yml
+++ b/7.1.N-extra-vars.yml
@@ -10,7 +10,7 @@ amps:
     version: 1.4.1
   device_sync:
     repository: "{{ nexus_repository.enterprise_releases }}/services/sync/alfresco-device-sync-repo"
-    version: 3.11.1
+    version: 3.11.3
   googledrive_repo:
     repository: "{{ nexus_repository.enterprise_releases }}/integrations/alfresco-googledrive-repo-enterprise"
     version: 3.2.2
@@ -47,7 +47,7 @@ adw:
   version: 2.6.1
 sync:
   repository: "{{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x"
-  version: 3.11.1
+  version: 3.11.3
 # this overwrites (and not merge) the same structure in group_vars/all.yml
 dependencies_version:
   postgresql_connector: 42.6.1

--- a/7.2.N-extra-vars.yml
+++ b/7.2.N-extra-vars.yml
@@ -2,14 +2,14 @@ acs:
   artifact_name: alfresco-content-services-distribution
   edition: Enterprise
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 7.2.1.14
+  version: 7.2.1.15
 amps:
   aos_module:
     repository: "{{ nexus_repository.releases }}/aos-module/alfresco-aos-module"
     version: 1.4.1
   device_sync:
     repository: "{{ nexus_repository.enterprise_releases }}/services/sync/alfresco-device-sync-repo"
-    version: 3.11.1
+    version: 3.11.3
   googledrive_repo:
     repository: "{{ nexus_repository.enterprise_releases }}/integrations/alfresco-googledrive-repo-enterprise"
     version: 3.2.2
@@ -27,7 +27,7 @@ search_enterprise:
 search:
   artifact_name: alfresco-search-services
   repository: "{{ nexus_repository.releases }}"
-  version: 2.0.9.1
+  version: 2.0.10
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
@@ -46,7 +46,7 @@ adw:
   version: 3.0.0
 sync:
   repository: "{{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x"
-  version: 3.11.1
+  version: 3.11.3
 dependencies_version:
   postgresql_connector: 42.6.1
   postgres_major_version: 13

--- a/7.3.N-extra-vars.yml
+++ b/7.3.N-extra-vars.yml
@@ -9,7 +9,7 @@ amps:
     version: 1.5.0
   device_sync:
     repository: "{{ nexus_repository.enterprise_releases }}/services/sync/alfresco-device-sync-repo"
-    version: 3.11.1
+    version: 3.11.3
   googledrive_repo:
     repository: "{{ nexus_repository.enterprise_releases }}/integrations/alfresco-googledrive-repo-enterprise"
     version: 3.3.1
@@ -27,7 +27,7 @@ search_enterprise:
 search:
   artifact_name: alfresco-search-services
   repository: "{{ nexus_repository.releases }}"
-  version: 2.0.9.1
+  version: 2.0.10
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
@@ -46,7 +46,7 @@ adw:
   version: 3.1.0
 sync:
   repository: "{{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x"
-  version: 3.11.1
+  version: 3.11.3
 dependencies_version:
   postgresql_connector: 42.6.1
   postgres_major_version: 13

--- a/7.4.N-extra-vars.yml
+++ b/7.4.N-extra-vars.yml
@@ -10,7 +10,7 @@ amps:
   device_sync:
     repository: >-
       {{ nexus_repository.enterprise_releases }}/services/sync/alfresco-device-sync-repo
-    version: 3.11.1
+    version: 3.11.3
   googledrive_repo:
     repository: >-
       {{ nexus_repository.enterprise_releases }}/integrations/alfresco-googledrive-repo-enterprise
@@ -26,11 +26,11 @@ api_explorer:
 search_enterprise:
   artifact_name: alfresco-elasticsearch-connector-distribution
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 3.3.2
+  version: 3.3.3
 search:
   artifact_name: alfresco-search-services
   repository: "{{ nexus_repository.releases }}"
-  version: 2.0.9.1
+  version: 2.0.10
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
@@ -50,7 +50,7 @@ adw:
 sync:
   repository: >-
     {{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x
-  version: 3.11.1
+  version: 3.11.3
 acc:
   artifact_name: alfresco-control-center
   repository: "{{ nexus_repository.releases }}"

--- a/community-extra-vars.yml
+++ b/community-extra-vars.yml
@@ -10,7 +10,7 @@ api_explorer:
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
-  version: 5.1.0
+  version: 5.1.1
 acc:
   artifact_name: alfresco-control-center
   repository: "{{ nexus_repository.releases }}"
@@ -18,7 +18,7 @@ acc:
 search:
   artifact_name: alfresco-search-services
   repository: "{{ nexus_repository.releases }}"
-  version: 2.0.9.1
+  version: 2.0.10
 amps:
   aos_module:
     repository: "{{ nexus_repository.releases }}/aos-module/alfresco-aos-module"

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -181,8 +181,9 @@ doc](./README.md#versioning)
 
 Follow this quick checklist:
 
-* copy the versions inside the group_vars/all.yml to a new X.X.N-extra-vars.yml
+* copy the versions inside the group_vars/all.yml to a new XX.N-extra-vars.yml (in case of a new ACS major version)
 * run [updatecli workflow](https://github.com/Alfresco/alfresco-ansible-deployment/actions/workflows/updatecli.yml)
+* run [enterprise-extended](https://github.com/Alfresco/alfresco-ansible-deployment/actions/workflows/enterprise-extended.yml) and make sure it is green
 * ensure that the [tables in the main readme](README.md) has been updated
 * ensure that AMI id for the root molecule tests are not too outdated (e.g. [default suite](../molecule/default/))
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -80,20 +80,21 @@ The table below shows the version of the components deployed by the playbook for
 | Component           | 23.2 Enterprise (Community) | 7.4 Enterprise | 7.3 Enterprise | 7.2 Enterprise | 7.1 Enterprise |
 |---------------------|-----------------------------|----------------|----------------|----------------|----------------|
 | OpenJDK             | 17.0.9                      | 17.0.3         | 17.0.3         | 11.0.15        | 11.0.15        |
-| Apache Tomcat       | 10.1.19                     | 9.0.86         | 9.0.86         | 9.0.86         | 9.0.86         |
+| Apache Tomcat       | 10.1.20                     | 9.0.86         | 9.0.86         | 9.0.86         | 9.0.86         |
 | PostgreSQL          | 15.x                        | 14.x           | 14.x           | 13.x           | 13.x           |
-| Apache ActiveMQ     | 5.18.3                      | 5.17.6         | 5.17.6         | 5.16.7         | 5.16.7         |
-| Repository          | 23.2.1                      | 7.4.1.6        | 7.3.1.2        | 7.2.1.13       | 7.1.1.10       |
-| Share               | 23.2.1                      | 7.4.1.6        | 7.3.1.2        | 7.2.1.13       | 7.1.1.10       |
-| Search Services     | 2.0.9.1                     | 2.0.9.1        | 2.0.9.1        | 2.0.9.1        | 2.0.2.2        |
-| Search Enterprise   | 4.0.1 (n/a)                 | 3.3.2          | 3.2.1          | 3.1.1.1        | 3.1.1.1        |
-| All-In-One T-Engine | 5.1.0                       | 4.0.1          | 3.1.2          | 3.1.2          | 3.1.2          |
+| Apache ActiveMQ     | 5.18.4                      | 5.17.6         | 5.17.6         | 5.16.7         | 5.16.7         |
+| Repository          | 23.2.1                      | 7.4.1.6        | 7.3.1.2        | 7.2.1.15       | 7.1.1.10       |
+| Share               | 23.2.1                      | 7.4.1.6        | 7.3.1.2        | 7.2.1.15       | 7.1.1.10       |
+| Search Services     | 2.0.10                      | 2.0.10         | 2.0.10         | 2.0.10         | 2.0.2.2        |
+| Search Enterprise   | 4.0.1 (n/a)                 | 3.3.3          | 3.2.1          | 3.1.1.1        | 3.1.1.1        |
+| All-In-One T-Engine | 5.1.1                       | 4.0.1          | 3.1.2          | 3.1.2          | 3.1.2          |
 | AOS                 | 3.0.0                       | 1.6.2          | 1.5.0          | 1.4.1          | 1.4.1          |
 | Google Docs         | 4.0.0                       | 3.4.2          | 3.3.1          | 3.2.2          | 3.2.1          |
-| Digital Workspace   | 4.4.0 (n/a)                 | 4.0.0          | 3.1.0          | 3.0.0          | 2.6.1          |
-| Transform Router    | 4.1.0 (n/a)                 | 3.0.1          | 2.1.2          | 2.1.2          | 2.1.2          |
-| Shared File Store   | 4.1.0 (n/a)                 | 3.0.1          | 2.1.2          | 2.1.2          | 2.1.2          |
-| Sync Service        | 4.0.1 (n/a)                 | 3.11.1         | 3.11.1         | 3.11.1         | 3.11.1         |
+| Digital Workspace   | 4.4.1 (n/a)                 | 4.0.0          | 3.1.0          | 3.0.0          | 2.6.1          |
+| Contro Center       | 8.4.1 (n/a)                 | 8.0.0          | n/a            | n/a            | n/a            |
+| Transform Router    | 4.1.1 (n/a)                 | 3.0.1          | 2.1.2          | 2.1.2          | 2.1.2          |
+| Shared File Store   | 4.1.1 (n/a)                 | 3.0.1          | 2.1.2          | 2.1.2          | 2.1.2          |
+| Sync Service        | 5.0.0 (n/a)                 | 3.11.1         | 3.11.1         | 3.11.1         | 3.11.1         |
 
 > Support for ACS 7.0 has been deprecated since April 2024, but you can still use the latest playbook that supported it ([v2.6.0](https://github.com/Alfresco/alfresco-ansible-deployment/releases/tag/v2.6.0))
 > Support for ACS 6.2 has been deprecated since November 2022, but you can still use the latest playbook that supported it ([v2.2.0](https://github.com/Alfresco/alfresco-ansible-deployment/releases/tag/v2.2.0))

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -182,11 +182,11 @@ use_custom_keystores: false
 dependencies_version:
   postgresql_connector: 42.6.1
   postgres_major_version: 15
-  activemq: 5.18.3
+  activemq: 5.18.4
   java: 17.0.9
   java_build: 9
-  tomcat: 10.1.19
-  libreoffice: 7.2.5.1
+  tomcat: 10.1.20
+  libreoffice: 7.2.5.2
   pdf_renderer: 1.1
   imagemagick: 7.1.0-16-ci-6
 apache_archive_url: https://archive.apache.org

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -33,7 +33,7 @@ amps:
   device_sync:
     repository: >-
       {{ nexus_repository.enterprise_releases }}/services/sync/alfresco-device-sync-repo
-    version: 4.0.1
+    version: 5.0.0
   googledrive_repo:
     repository: >-
       {{ nexus_repository.enterprise_releases }}/integrations/alfresco-googledrive-repo-enterprise
@@ -73,7 +73,7 @@ adw:
 sync:
   repository: >-
     {{ nexus_repository.enterprise_releases }}/services/sync/sync-dist-6.x
-  version: 4.0.1
+  version: 5.0.0
 acc:
   artifact_name: alfresco-control-center
   repository: "{{ nexus_repository.releases }}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -186,7 +186,7 @@ dependencies_version:
   java: 17.0.9
   java_build: 9
   tomcat: 10.1.20
-  libreoffice: 7.2.5.2
+  libreoffice: 7.2.5.1
   pdf_renderer: 1.1
   imagemagick: 7.1.0-16-ci-6
 apache_archive_url: https://archive.apache.org

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -53,19 +53,19 @@ search_enterprise:
 search:
   artifact_name: alfresco-search-services
   repository: "{{ nexus_repository.releases }}"
-  version: 2.0.9.1
+  version: 2.0.10
 transform:
   artifact_name: alfresco-transform-core-aio
   repository: "{{ nexus_repository.releases }}"
-  version: 5.1.0
+  version: 5.1.1
 trouter:
   artifact_name: alfresco-transform-router
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 4.1.0
+  version: 4.1.1
 sfs:
   artifact_name: alfresco-shared-file-store-controller
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 4.1.0
+  version: 4.1.1
 adw:
   artifact_name: alfresco-digital-workspace
   repository: "{{ nexus_repository.enterprise_releases }}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -181,7 +181,7 @@ use_custom_keystores: false
 # to default ansible merging behaviour
 dependencies_version:
   postgresql_connector: 42.6.1
-  postgres_major_version: 15
+  postgres_major_version: 14
   activemq: 5.18.4
   java: 17.0.9
   java_build: 9

--- a/roles/activemq/defaults/main.yml
+++ b/roles/activemq/defaults/main.yml
@@ -9,4 +9,4 @@ activemq_environment:
     - -Xms128m
     - -Xmx1g
     - $ACTIVEMQ_OPTS
-activemq_version: 5.18.3
+activemq_version: 5.18.4

--- a/scripts/updatecli/updatecli_acs23.yml
+++ b/scripts/updatecli/updatecli_acs23.yml
@@ -14,7 +14,7 @@ apiExplorer:
   version: "23.2"
 
 dsync:
-  version: "4.0"
+  version: "5.0"
 
 googleDrive:
   version: "4.1"

--- a/tests/test-config-7.1.json
+++ b/tests/test-config-7.1.json
@@ -23,7 +23,7 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "installed": true
           }
         ]

--- a/tests/test-config-7.2.json
+++ b/tests/test-config-7.2.json
@@ -23,7 +23,7 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "installed": true
           }
         ]

--- a/tests/test-config-7.3.json
+++ b/tests/test-config-7.3.json
@@ -23,7 +23,7 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "installed": true
           }
         ]

--- a/tests/test-config-7.4.json
+++ b/tests/test-config-7.4.json
@@ -23,7 +23,7 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "3.11.1",
+            "version": "3.11.3",
             "installed": true
           }
         ]

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -23,7 +23,7 @@
           },
           {
             "id": "org_alfresco_device_sync_repo",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "installed": true
           }
         ]


### PR DESCRIPTION
Ref: OPSEXP-2627

Tests of Deprecated versions: https://github.com/Alfresco/alfresco-ansible-deployment/actions/runs/8733936648