### PR TITLE
OPSEXP-2777 Revert to last official AMI for ubuntu 18.04

### DIFF
--- a/molecule/default/vars-ubuntu18.yml
+++ b/molecule/default/vars-ubuntu18.yml
@@ -1,4 +1,4 @@
-MOLECULE_IT_IMAGE_ID: ami-02076d50a3b3930d0 #  (SupportedImages) - Ubuntu 18.04 LTS x86_64 LATEST - 20240610-6f3aa60e-6d45-416e-b6b8-54900c63ddba
+MOLECULE_IT_IMAGE_ID: ami-0e42de9d667b232f7 # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20230531
 MOLECULE_IT_EXTRA_VARS: 7.1.N-extra-vars.yml
 MOLECULE_IT_TEST_CONFIG: tests/test-config-7.1.json
 MOLECULE_IT_PLATFORM: ubuntu18


### PR DESCRIPTION
<img width="1144" alt="Screenshot 2024-08-30 at 10 51 58" src="https://github.com/user-attachments/assets/a5758f4a-9ea3-49ab-92d8-b165fbffaf96">

Supported Images are paid images.