### PR TITLE
OPSEXP-:2330: re-enable ATS test in cluster (with off-cluster node) after ACS-6670 fix

### DIFF
--- a/molecule/multimachine/host_vars/repository_neutron.yml
+++ b/molecule/multimachine/host_vars/repository_neutron.yml
@@ -1,2 +1,2 @@
 # variables for molecule tests - inventory_hostname: repository_neutron
-cluster_keepoff: false  # workaround while investigating transformation issues (tracked in OPSEXP-2330)
+cluster_keepoff: true


### PR DESCRIPTION
Ref: OPSEXP-2330