### PR TITLE
OPSEXP-2330: re-enable ATS test in cluster (with off-cluster node) after ACS-6670 fix

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -25,7 +25,7 @@ acs:
   artifact_name: alfresco-content-services-distribution
   edition: Enterprise
   repository: "{{ nexus_repository.enterprise_releases }}"
-  version: 23.3.2
+  version: 23.4.0-A15
 amps:
   aos_module:
     repository: "{{ nexus_repository.releases }}/aos-module/alfresco-aos-module"

--- a/molecule/multimachine/host_vars/repository_neutron.yml
+++ b/molecule/multimachine/host_vars/repository_neutron.yml
@@ -1,2 +1,2 @@
 # variables for molecule tests - inventory_hostname: repository_neutron
-cluster_keepoff: false  # workaround while investigating transformation issues (tracked in OPSEXP-2330)
+cluster_keepoff: true


### PR DESCRIPTION
Ref: OPSEXP-2330