### PR TITLE
OPSEXP-3019 Switch to arm64 GA runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,7 +82,7 @@ jobs:
           cache-name: ${{ inputs.galaxy_cache }}
 
       - name: Install required tools for arm runners
-        uses: Alfresco/alfresco-build-tools/.github/actions/install-ubuntu-default-tools@OPSEXP-3019-cleanup-ubuntu-tools
+        uses: Alfresco/alfresco-build-tools/.github/actions/install-ubuntu-default-tools@15e09b8065507210cb1cc33c8bc778b1fb4f289d # v8.10.0
         if: contains(inputs.runner, '-arm')
 
       - name: Run tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,10 @@ jobs:
         with:
           cache-name: ${{ inputs.galaxy_cache }}
 
+      - name: Install required tools for arm runners
+        uses: Alfresco/alfresco-build-tools/.github/actions/install-ubuntu-default-tools@16272633584df58ea603112c4aac4564c8673cd6 # v8.9.0
+        if: contains(inputs.runner, '-arm')
+
       - name: Run tests
         env:
           MOLECULE_ROLE_IMAGE: ${{ inputs.os_distribution }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,7 +82,7 @@ jobs:
           cache-name: ${{ inputs.galaxy_cache }}
 
       - name: Install required tools for arm runners
-        uses: Alfresco/alfresco-build-tools/.github/actions/install-ubuntu-default-tools@16272633584df58ea603112c4aac4564c8673cd6 # v8.9.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/install-ubuntu-default-tools@OPSEXP-3019-cleanup-ubuntu-tools
         if: contains(inputs.runner, '-arm')
 
       - name: Run tests

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -146,17 +146,17 @@ jobs:
               name: docker_enterprise
             molecule_distro:
               image: rockylinux/rockylinux:9.4
-            runner: ubuntu-latest-arm64-small
+            runner: ubuntu-24.04-arm
           - scenario:
               name: docker_enterprise
             molecule_distro:
               image: ubuntu:22.04
-            runner: ubuntu-latest-arm64-small
+            runner: ubuntu-24.04-arm
           - scenario:
               name: docker_enterprise
             molecule_distro:
               image: ubuntu:24.04
-            runner: ubuntu-latest-arm64-small
+            runner: ubuntu-24.04-arm
 
     uses: ./.github/workflows/docker.yml
     with:
@@ -164,7 +164,7 @@ jobs:
       os_distribution: ${{ matrix.molecule_distro.image }}
       galaxy_cache: enterprise
       dtas_version: ${{ needs.docker.outputs.dtas_version }}
-      dtas_additional_params: ${{ matrix.runner == 'ubuntu-latest-arm64-small' && '-k "not test_transformation"' || '' }}
+      dtas_additional_params: ${{ matrix.runner == 'ubuntu-24.04-arm' && '-k "not test_transformation"' || '' }}
       runner: ${{ matrix.runner }}
     secrets:
       nexus_username: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   updatecli:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: "${{ matrix.values-file }}"
     if: github.actor != 'dependabot[bot]'
     strategy:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * MON'
-  pull_request:
+  push:
     paths:
       - '.github/workflows/updatecli.yml'
       - 'scripts/updatecli/**'


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

requires:
* https://github.com/Alfresco/alfresco-build-tools/pull/876