### PR TITLE
Avoid using quote filter when not constructing a single shell token

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -753,7 +753,7 @@ repository:
         - -Dencryption.cipherAlgorithm=AES/CBC/PKCS5Padding
         - -Dencryption.keyAlgorithm=AES
         - -Dencryption.keystore.location=/var/opt/alfresco/content-services/keystore/<your-keystore-file>
-        - -Dmetadata-keystore.metadata.algorithm=AES"
+        - -Dmetadata-keystore.metadata.algorithm=AES
 ```
 
 ### Specifying a different component repository

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -21,15 +21,15 @@
     - name: Set solr.sharedSecret property when search secret is available
       ansible.builtin.set_fact:
         temp_array: >-
-          {{ temp_array + [ '-Dsolr.sharedSecret=' ~ reposearch_shared_secret | quote ] }}
+          {{ temp_array + [ '-Dsolr.sharedSecret=' ~ reposearch_shared_secret ] }}
       when: (acs.version is version('7.2.0', '>=')) and (reposearch_shared_secret is defined)
 
     - name: Set metadata-keystore.password and related properties
       ansible.builtin.set_fact:
         temp_array: "{{ temp_array + [
-          '-Dmetadata-keystore.password=' ~ repo_custom_keystore_password | quote,
+          '-Dmetadata-keystore.password=' ~ repo_custom_keystore_password,
           '-Dmetadata-keystore.aliases=metadata',
-          '-Dmetadata-keystore.metadata.password=' ~ repo_custom_keystore_metadata_password | quote
+          '-Dmetadata-keystore.metadata.password=' ~ repo_custom_keystore_metadata_password
           ] }}"
       when:
         - repo_custom_keystore_password is defined

--- a/roles/search/templates/solr.sh.j2
+++ b/roles/search/templates/solr.sh.j2
@@ -5,7 +5,7 @@ if [ $(id -u) -eq 0 ]; then
 fi
 . {{ config_folder }}/setenv.sh
 {% if acs.version is version('7.2.0', '>=') -%}
-export JAVA_TOOL_OPTIONS="-Dalfresco.secureComms.secret={{ search_shared_secret | quote }}"
+export JAVA_TOOL_OPTIONS="-Dalfresco.secureComms.secret={{ search_shared_secret }}"
 {% endif %}
 export SOLR_INCLUDE={{ config_dir }}/solr.in.sh
 {{ binaries_dir }}/solr/bin/solr $*


### PR DESCRIPTION
Fix #806 