### PR TITLE
OPSEXP-2923 Bump keycloak to v25

### DIFF
--- a/roles/identity/defaults/main.yml
+++ b/roles/identity/defaults/main.yml
@@ -3,7 +3,7 @@
 identity_admin_username: admin
 identity_admin_password: null
 
-identity_keycloak_quarkus_version: "24.0.5"
+identity_keycloak_quarkus_version: "25.0.6"
 identity_alfresco_theme_version: "0.3.5"
 
 identity_keycloak_http_port: 8080

--- a/roles/identity/tasks/main.yml
+++ b/roles/identity/tasks/main.yml
@@ -13,6 +13,6 @@
     keycloak_quarkus_admin_url: "{{ identity_url }}"
     keycloak_quarkus_additional_env_vars:
       - key: KC_FEATURES
-        value: hostname:v1
+        value: hostname:v1 # retrocompatibility with Keycloak 24
   ansible.builtin.include_role:
     name: middleware_automation.keycloak.keycloak_quarkus

--- a/roles/identity/tasks/main.yml
+++ b/roles/identity/tasks/main.yml
@@ -11,5 +11,8 @@
     keycloak_quarkus_http_relative_path: "{{ identity_keycloak_http_relative_path }}"
     keycloak_quarkus_frontend_url: "{{ identity_url }}"
     keycloak_quarkus_admin_url: "{{ identity_url }}"
+    keycloak_quarkus_additional_env_vars:
+      - key: KC_FEATURES
+        value: hostname:v1
   ansible.builtin.include_role:
     name: middleware_automation.keycloak.keycloak_quarkus


### PR DESCRIPTION
Bump to v25 as per [supported platforms](https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/23.4/Alfresco-Content-Services/Supported-Platforms)

OPSEXP-2923