### PR TITLE
Enable dependabot for cache-downloads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
       interval: "monthly"
 
   - package-ecosystem: "github-actions"
+    directory: "/.github/actions/cache-downloads"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "github-actions"
     directory: "/.github/actions/molecule_integration_ec2"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Still getting the deprecation notice:
> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
