### PR TITLE
OPSEXP-3015: set secure, sensible yet usable default for max upload files

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@ export AWS_REGION=eu-west-1
 export MOLECULE_IT_AWS_VPC_SUBNET_ID=subnet-6bdd4223
 export BRANCH_NAME=local
 export BUILD_NUMBER=1
-export DTAS_VERSION=v1.6.0
+export DTAS_VERSION=v1.6.1
 export MOLECULE_IT_ID=$(echo "$LOGNAME" | sha256sum | cut -c1-6)
 ANSIBLE_VAULT_PASSWORD_FILE=$(expand_path ./.vault_pass.txt)
 export ANSIBLE_VAULT_PASSWORD_FILE

--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 env:
-  DTAS_VERSION: v1.6.0
+  DTAS_VERSION: v1.6.1
   BUILD_NUMBER: ${{ github.run_id }}
   PY_COLORS: 1
   PYTHONUNBUFFERED: 1

--- a/roles/adf_app/templates/default_server.conf.j2
+++ b/roles/adf_app/templates/default_server.conf.j2
@@ -1,6 +1,5 @@
 server {
         listen {{ adf_app_port }};
-        client_max_body_size 0;
 
         set  $allowOriginSite *;
         proxy_pass_request_headers on;

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -11,4 +11,9 @@ setup_vhosts: true
 
 # Disable when nginx node is behind another reverse proxy (e.g. AWS ELB)
 nginx_set_proxy_headers: true
+
 nginx_absolute_redirect: true
+
+# Allow 5GB or 20 minutes long max uploads by default
+nginx_client_max_body_size: "5g"
+nginx_client_body_timeout: "20m"

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -15,5 +15,5 @@ nginx_set_proxy_headers: true
 nginx_absolute_redirect: true
 
 # Allow 5GB or 20 minutes long max uploads by default
-nginx_client_max_body_size: "5g"
-nginx_client_body_timeout: "20m"
+nginx_max_upload_size: "5g"
+nginx_max_upload_time: "20m"

--- a/roles/nginx/meta/argument_specs.yml
+++ b/roles/nginx/meta/argument_specs.yml
@@ -18,3 +18,11 @@ argument_specs:
         description: Useful when nginx node is behind another reverse proxy (e.g. should be disabled when behind an AWS ELB)
         type: bool
         default: true
+      nginx_client_max_body_size:
+        description: The maximum allowed size of the client request body
+        type: str
+        default: 5g
+      nginx_client_body_timeout:
+        description: The timeout for reading the client request body
+        type: str
+        default: 20m

--- a/roles/nginx/meta/argument_specs.yml
+++ b/roles/nginx/meta/argument_specs.yml
@@ -18,11 +18,11 @@ argument_specs:
         description: Useful when nginx node is behind another reverse proxy (e.g. should be disabled when behind an AWS ELB)
         type: bool
         default: true
-      nginx_client_max_body_size:
-        description: The maximum allowed size of the client request body
+      nginx_max_upload_size:
+        description: The maximum allowed size of an upload (client request body)
         type: str
         default: 5g
-      nginx_client_body_timeout:
-        description: The timeout for reading the client request body
+      nginx_max_upload_time:
+        description: Timeout of uploads (client requests read timeout)
         type: str
         default: 20m

--- a/roles/nginx/templates/alfresco_proxy.include.j2
+++ b/roles/nginx/templates/alfresco_proxy.include.j2
@@ -1,5 +1,3 @@
-    client_max_body_size 0;
-
     absolute_redirect {{ 'on' if nginx_absolute_redirect else 'off' }};
 
     set  $allowOriginSite *;
@@ -30,11 +28,15 @@
     #ENV_ACCESS_LOG
 
     location /share/ {
+        client_max_body_size {{ nginx_client_max_body_size }};
+        client_body_timeout {{ nginx_client_body_timeout }};
         proxy_pass http://share_lb;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
     location /alfresco/ {
+        client_max_body_size {{ nginx_client_max_body_size }};
+        client_body_timeout {{ nginx_client_body_timeout }};
         proxy_pass http://repo_lb;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }

--- a/roles/nginx/templates/alfresco_proxy.include.j2
+++ b/roles/nginx/templates/alfresco_proxy.include.j2
@@ -28,15 +28,15 @@
     #ENV_ACCESS_LOG
 
     location /share/ {
-        client_max_body_size {{ nginx_client_max_body_size }};
-        client_body_timeout {{ nginx_client_body_timeout }};
+        client_max_body_size {{ nginx_max_upload_size }};
+        client_body_timeout {{ nginx_max_upload_time }};
         proxy_pass http://share_lb;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }
 
     location /alfresco/ {
-        client_max_body_size {{ nginx_client_max_body_size }};
-        client_body_timeout {{ nginx_client_body_timeout }};
+        client_max_body_size {{ nginx_max_upload_size }};
+        client_body_timeout {{ nginx_max_upload_time }};
         proxy_pass http://repo_lb;
         include {{ nginx_vhost_path }}/alfresco_proxy_headers.include;
     }


### PR DESCRIPTION
Ref: OPSEX-3015

* Removes limitless requests sizes for adf_app (default should be fine)
* Set more secure requests size and duration limits for repo & share