### PR TITLE
OPSEXP-3118: move ES version to version vars

### DIFF
--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -123,7 +123,7 @@
   gather_facts: false
   roles:
     - role: "../roles/elasticsearch"
-      elasticsearch_major_version: "{{ '8.x' if acs_play_repository_acs_version is version('25.0', 'ge') else '7.x' }}"
+      elasticsearch_major_version: "{{ acs_play_elasticsearch_major_version }}"
       when: acs_is_enterprise and not groups.external_elasticsearch | default([])
   tags:
     - elasticsearch

--- a/playbooks/group_vars/elasticsearch.yml
+++ b/playbooks/group_vars/elasticsearch.yml
@@ -1,0 +1,1 @@
+acs_play_elasticsearch_major_version: 7.x


### PR DESCRIPTION
Use var to pass ES (major) version so can be overridden in a version specific way when needed
Ref: OPSEXP-3118