### PR TITLE
OPSEXP-3176 Fixup ami bumps for latest RH/RL supported versions

### DIFF
--- a/.github/updatecli/updatecli_amis_values.yml
+++ b/.github/updatecli/updatecli_amis_values.yml
@@ -3,14 +3,14 @@ amis:
     pattern: RHEL-8.10.0_HVM-*
     owner_id: "309956199498"
   rhel9:
-    pattern: RHEL-9.4.0_HVM-*
+    pattern: RHEL-9.5.0_HVM-*
     owner_id: "309956199498"
   rl8:
     pattern: Rocky-8-EC2-Base-8.10-*
     volume_type: gp2
     owner_id: "792107900819"
   rl9:
-    pattern: Rocky-9-EC2-Base-9.4-*
+    pattern: Rocky-9-EC2-Base-9.5-*
     volume_type: gp2
     owner_id: "792107900819"
   ub22:


### PR DESCRIPTION
The initial config was made using master configs before merging the v25 updates

OPSEXP-3176