### PR TITLE
Fix external hosts usage in playbooks

### DIFF
--- a/playbooks/dynamic-facts.yml
+++ b/playbooks/dynamic-facts.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set dynamic facts for play
-  hosts: localhost:all
+  hosts: localhost:all:!external
   gather_facts: false
   tasks:
     - name: Validate acs edition value

--- a/playbooks/include-vars.yml
+++ b/playbooks/include-vars.yml
@@ -1,6 +1,6 @@
 ---
 - name: Include vars based on acs major version
-  hosts: localhost:all
+  hosts: localhost:all:!external
   gather_facts: false
   vars:
     base_folder: "{{ playbook_dir }}/.."

--- a/playbooks/platform-cleanup.yml
+++ b/playbooks/platform-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Clean artifacts post deployment
-  hosts: all
+  hosts: all:!external
   vars:
     artifacts_path: "{{ download_location | default('/tmp/ansible_artefacts') }}"
   tasks:


### PR DESCRIPTION
It would fails otherwise when having at least one external activemq/elasticsearch/identity