### PR TITLE
OPSEXP-3170 Add workflow to cleanup AWS MQ configuration leftovers

### DIFF
--- a/.github/workflows/aws-mq-cleanup.yml
+++ b/.github/workflows/aws-mq-cleanup.yml
@@ -2,6 +2,11 @@ name: Cleanup MQ Configurations
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: true
+        description: "If true, skips deletion for safe testing"
   schedule:
     - cron: '23 5 1 * *'
 
@@ -12,6 +17,7 @@ permissions:
 env:
   RETENTION_DAYS: 30
   AWS_REGION: eu-west-1
+  DRY_RUN: ${{ inputs.dry_run && github.event_name != 'schedule' }}
 
 jobs:
   delete-mq-configs:
@@ -69,8 +75,12 @@ jobs:
               fi
 
               if [ "$created_epoch" -lt "$threshold_epoch" ]; then
-                echo "Deleting: $name ($id) — $age_days days old"
-                aws mq delete-configuration --configuration-id "$id"
+                if [ "$DRY_RUN" = "false" ]; then
+                  echo "Deleting: $name ($id) — $age_days days old"
+                  aws mq delete-configuration --configuration-id "$id"
+                else
+                  echo "Dry run would delete: $name ($id) — $age_days days old"
+                fi
               else
                 echo "Keeping: $name ($id) — $age_days days old"
               fi

--- a/.github/workflows/aws-mq-cleanup.yml
+++ b/.github/workflows/aws-mq-cleanup.yml
@@ -1,28 +1,26 @@
 name: Cleanup MQ Configurations
+
 on:
   workflow_dispatch:
-    inputs:
-      aws_region:
-        description: "AWS region where MQ configurations need to be cleaned up"
-        type: string
-        default: eu-west-1
   schedule:
     - cron: '23 5 1 * *'
+
 permissions:
   id-token: write
   contents: read
+
 env:
   RETENTION_DAYS: 30
+  AWS_REGION: eu-west-1
+
 jobs:
   delete-mq-configs:
-
     runs-on: ubuntu-latest
     steps:
-
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          aws-region: ${{ inputs.aws_region }}
+          aws-region:  ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/mq-configuration-cleanup
           role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 1800
@@ -59,7 +57,6 @@ jobs:
               created=$(jq -r '.LatestRevision.Created' <<< "$config")
               created_epoch=$(date -d "${created%%.*}" +"%s" || echo 0)
 
-
               age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
 
               attached=$(aws mq list-brokers \
@@ -78,7 +75,6 @@ jobs:
                 echo "Keeping: $name ($id) — $age_days days old"
               fi
             done < <(echo "$configs")
-
 
             # Exit loop if no more pages
             [ "$next_token" == "null" ] || [ -z "$next_token" ] && break

--- a/.github/workflows/aws-mq-cleanup.yml
+++ b/.github/workflows/aws-mq-cleanup.yml
@@ -1,23 +1,29 @@
-name: Delete MQ Configurations
+name: Cleanup MQ Configurations
 permissions:
   id-token: write
   contents: read
 on:
-  workflow_dispatch:  
+  workflow_dispatch:
+    inputs:
+      aws_region-updatecli-ref:
+        description: "AWS region where MQ configurations need to be cleaned up"
+        type: string
+        default: eu-west-1
   schedule:
-    - cron: '0 0 1 * *'  
+    - cron: '0 0 1 * *'
 
 jobs:
   delete-mq-configs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Configure AWS credentials
+      - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_SECRET_ACCESS_KEY}}
-          aws-region: eu-west-1
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/mq-configuration-cleanup
+          role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: 1800
 
       - name: Delete old MQ configurations (using pagination)
         run: |
@@ -75,9 +81,3 @@ jobs:
             # Exit loop if no more pages
             [ "$next_token" == "null" ] || [ -z "$next_token" ] && break
           done
-      
-
-
-
-
-

--- a/.github/workflows/aws-mq-cleanup.yml
+++ b/.github/workflows/aws-mq-cleanup.yml
@@ -1,19 +1,21 @@
 name: Cleanup MQ Configurations
-permissions:
-  id-token: write
-  contents: read
 on:
   workflow_dispatch:
     inputs:
-      aws_region-updatecli-ref:
+      aws_region:
         description: "AWS region where MQ configurations need to be cleaned up"
         type: string
         default: eu-west-1
   schedule:
-    - cron: '0 0 1 * *'
-
+    - cron: '23 5 1 * *'
+permissions:
+  id-token: write
+  contents: read
+env:
+  RETENTION_DAYS: 30
 jobs:
   delete-mq-configs:
+
     runs-on: ubuntu-latest
     steps:
 
@@ -27,18 +29,19 @@ jobs:
 
       - name: Delete old MQ configurations (using pagination)
         run: |
-          set -e
-          retention_days=30
-          threshold_epoch=$(date -d "$retention_days days ago" +"%s")
+          set -o pipefail
+          threshold_epoch=$(date -d "$RETENTION_DAYS  days ago" +"%s")
           next_token=""
 
-          echo "Checking for MQ configurations older than $retention_days days..."
+          echo "Checking for MQ configurations older than $RETENTION_DAYS days..."
 
           while true; do
+            list_configurations_cmd="aws mq list-configurations --max-results 100 --output json"
+
             if [ -z "$next_token" ]; then
-              response=$(aws mq list-configurations --max-results 100 --output json)
+              response=$($list_configurations_cmd )
             else
-              response=$(aws mq list-configurations --max-results 100 --next-token "$next_token" --output json)
+              response=$($list_configurations_cmd --next-token "$next_token" )
             fi
 
             configs=$(echo "$response" | jq -c '.Configurations[]?')
@@ -54,9 +57,8 @@ jobs:
               fi
 
               created=$(jq -r '.LatestRevision.Created' <<< "$config")
-              created_clean="${created%%.*}"
-              created_epoch=$(date -d "$created_clean" +"%s" 2>/dev/null || \
-                              date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
+              created_epoch=$(date -d "${created%%.*}" +"%s" || echo 0)
+
 
               age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
 

--- a/.github/workflows/aws-mq-cleanup.yml
+++ b/.github/workflows/aws-mq-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Delete old MQ configurations (using pagination)
         run: |
           set -o pipefail
-          threshold_epoch=$(date -d "$RETENTION_DAYS  days ago" +"%s")
+          threshold_epoch=$(date -d "$RETENTION_DAYS days ago" +"%s")
           next_token=""
 
           echo "Checking for MQ configurations older than $RETENTION_DAYS days..."
@@ -43,9 +43,9 @@ jobs:
             list_configurations_cmd="aws mq list-configurations --max-results 100 --output json"
 
             if [ -z "$next_token" ]; then
-              response=$($list_configurations_cmd )
+              response=$($list_configurations_cmd)
             else
-              response=$($list_configurations_cmd --next-token "$next_token" )
+              response=$($list_configurations_cmd --next-token "$next_token")
             fi
 
             configs=$(echo "$response" | jq -c '.Configurations[]?')
@@ -61,7 +61,7 @@ jobs:
               fi
 
               created=$(jq -r '.LatestRevision.Created' <<< "$config")
-              created_epoch=$(date -d "${created%%.*}" +"%s" || echo 0)
+              created_epoch=$(date -d "${created%%.*}" +"%s")
 
               age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -1,0 +1,23 @@
+
+name: Delete MQ Configurations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  delete-mq-configs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to AWS
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          aws-region: ${{ inputs.aws_region }}
+          role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/alfresco-cloud-deploy
+          role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: 5400    
+
+      - name: List MQ 
+        run: |
+          aws mq list-configurations \
+            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,EngineVersion]" \
+            --output table

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -27,8 +27,10 @@ jobs:
           aws-region: eu-west-1
       - name: Delete MQ 
         run: |
-          retention_days=1000
+          retention_days=30
           now=$(date -u +"%s")
+          count=0
+          count_skip=0
 
           configs=$(aws mq list-configurations \
             --no-paginate \
@@ -39,19 +41,21 @@ jobs:
             config_id=$(jq -r '.ID' <<< "$config")
             config_name=$(jq -r '.Name' <<< "$config")
             created=$(jq -r '.Created' <<< "$config")
-            
+
             created_epoch=$(date -d "$created" +"%s" 2>/dev/null || \
                             date -j -f "%Y-%m-%dT%H:%M:%S" "$(echo "$created" | cut -d. -f1)" +"%s")
             age_days=$(( (now - created_epoch) / 86400 ))
 
             if [ "$age_days" -gt "$retention_days" ]; then
               echo "Deleting configuration $config_name (ID: $config_id, Age: $age_days days)"
-              aws mq delete-configuration --configuration-id "$config_id"
-              break
+              count=$((count + 1))
             else
               echo "Skipping configuration $config_name (ID: $config_id, Age: $age_days days)"
+              count_skip=$((count_skip + 1))
             fi
           done
+          echo "delete count $count"
+          echo "skip count $count_skip"
 
 
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -3,10 +3,9 @@ permissions:
   id-token: write
   contents: read
 on:
-  push:
-    branches:
-      - OPSEXP-3170
   workflow_dispatch:  
+  schedule:
+    - cron: '0 0 1 * *'  
 
 jobs:
   delete-mq-configs:
@@ -25,9 +24,6 @@ jobs:
           set -e
           retention_days=30
           threshold_epoch=$(date -d "$retention_days days ago" +"%s")
-
-          total_checked=0
-          total_deleted=0
           next_token=""
 
           echo "Checking for MQ configurations older than $retention_days days..."
@@ -57,7 +53,6 @@ jobs:
                               date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
 
               age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
-              total_checked=$((total_checked + 1))
 
               attached=$(aws mq list-brokers \
                 --query "BrokerSummaries[?Configuration.Id=='$id'].BrokerId" \
@@ -70,13 +65,7 @@ jobs:
 
               if [ "$created_epoch" -lt "$threshold_epoch" ]; then
                 echo "Deleting: $name ($id) — $age_days days old"
-                total_deleted=$((total_deleted + 1))
-
-                if [ "$total_deleted" -ge 20 ]; then
-                  echo "deleted 20 records"
-                  aws mq delete-configuration --configuration-id "$id"
-                  break 2
-                fi
+                aws mq delete-configuration --configuration-id "$id"
               else
                 echo "Keeping: $name ($id) — $age_days days old"
               fi

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -94,6 +94,10 @@ jobs:
             echo "$configs" | while read -r config; do
               id=$(jq -r '.Id' <<< "$config")
               name=$(jq -r '.Name' <<< "$config")
+              if [[ "$name" != molecule-* ]]; then
+                echo "Skipping: $name (ID: $id) — doesn't match prefix 'molecule-'"
+                continue
+              fi
               created=$(jq -r '.LatestRevision.Created' <<< "$config")
 
               created_clean="${created%%.*}"

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -25,8 +25,32 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_SECRET_ACCESS_KEY}}
           aws-region: eu-west-1
-      - name: List MQ 
+      - name: Delete MQ 
         run: |
-          aws mq list-configurations \
-            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
-            --output table
+          retention_days=30
+          now=$(date -u +"%s")
+
+          configs=$(aws mq list-configurations \
+            --query "Configurations[?starts_with(Name, 'molecule-')].{ID:Id, Name:Name, Created:LatestRevision.Created}" \
+            --output json)
+
+          echo "$configs" | jq -c '.[]' | while read -r config; do
+            config_id=$(jq -r '.ID' <<< "$config")
+            config_name=$(jq -r '.Name' <<< "$config")
+            created=$(jq -r '.Created' <<< "$config")
+
+            # Convert created date to epoch (supports Linux/macOS)
+            created_epoch=$(date -d "$created" +"%s" 2>/dev/null || \
+                            date -j -f "%Y-%m-%dT%H:%M:%S" "$(echo "$created" | cut -d. -f1)" +"%s")
+            age_days=$(( (now - created_epoch) / 86400 ))
+
+            if [ "$age_days" -gt "$retention_days" ]; then
+              echo "Deleting configuration $config_name (ID: $config_id, Age: $age_days days)"
+            else
+              echo "Skipping configuration $config_name (ID: $config_id, Age: $age_days days)"
+            fi
+          done
+
+
+
+

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test Pagination for MQ Configurations
         run: |
           aws mq list-configurations \
-            --max-items 100 \
+            --max-results 100 \
             --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
             --output table       
       - name: Delete MQ 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -1,4 +1,3 @@
-
 name: Delete MQ Configurations
 
 on:

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -1,5 +1,7 @@
 name: Delete MQ Configurations
-
+permissions:
+  id-token: write
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -120,6 +120,12 @@ jobs:
               if [ "$created_epoch" -lt "$threshold_epoch" ]; then
                 echo "Deleting: $name ($id) — $age_days days old"
                 total_deleted=$((total_deleted + 1))
+                echo "check number: $total_checked"
+                if [ "$total_deleted" -ge 20 ]; then
+                  echo "deleted 20 records"
+                  break 2
+                fi
+
               else
                 echo "Keeping: $name ($id) — $age_days days old"
               fi

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -12,63 +12,14 @@ jobs:
   delete-mq-configs:
     runs-on: ubuntu-latest
     steps:
-      # - name: Login to AWS
-      #   uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
-      #   with:
-      #     aws-region: eu-west-1
-      #     role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/alfresco-cloud-deploy
-      #     role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
-      #     role-duration-seconds: 5400    
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_SECRET_ACCESS_KEY}}
           aws-region: eu-west-1
-      - name: List MQ 
-        run: |
-          aws mq list-configurations \
-            --no-paginate \
-            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,EngineVersion]" \
-            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
-            --output table  
-      - name: Test Pagination for MQ Configurations
-        run: |
-          aws mq list-configurations \
-            --max-results 100 \
-            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
-            --output table       
-      - name: Delete MQ 
-        run: |
-          retention_days=30
-          now=$(date -u +"%s")
-          count=0
-          count_skip=0
 
-          configs=$(aws mq list-configurations \
-            --no-paginate \
-            --query "Configurations[?starts_with(Name, 'molecule-')].{ID:Id, Name:Name, Created:LatestRevision.Created}" \
-            --output json)          
-          while read -r config; do
-            config_id=$(jq -r '.ID' <<< "$config")
-            config_name=$(jq -r '.Name' <<< "$config")
-            created=$(jq -r '.Created' <<< "$config")
-
-            created_epoch=$(date -d "${created%%.*}" +"%s" 2>/dev/null || \
-                            date -j -f "%Y-%m-%dT%H:%M:%S" "${created%%.*}" +"%s")
-            age_days=$(( (now - created_epoch) / 86400 ))
-
-            if [ "$age_days" -gt "$retention_days" ]; then
-              echo "Deleting configuration $config_name (ID: $config_id, Age: $age_days days)"
-              count=$((count + 1))
-            else
-              echo "Skipping configuration $config_name (ID: $config_id, Age: $age_days days)"
-              count_skip=$((count_skip + 1))
-            fi
-          done < <(echo "$configs" | jq -c '.[]')
-
-          echo "delete count: $count"
-          echo "skip count: $count_skip"
       - name: Delete old MQ configurations (using pagination)
         run: |
           set -e
@@ -79,7 +30,7 @@ jobs:
           total_deleted=0
           next_token=""
 
-          echo "🔍 Checking for MQ configurations older than $retention_days days..."
+          echo "Checking for MQ configurations older than $retention_days days..."
 
           while true; do
             if [ -z "$next_token" ]; then
@@ -123,6 +74,7 @@ jobs:
 
                 if [ "$total_deleted" -ge 20 ]; then
                   echo "deleted 20 records"
+                  aws mq delete-configuration --configuration-id "$id"
                   break 2
                 fi
               else
@@ -134,10 +86,6 @@ jobs:
             # Exit loop if no more pages
             [ "$next_token" == "null" ] || [ -z "$next_token" ] && break
           done
-
-          echo "--------------------------------------------------"
-          echo "Total configs checked: $total_checked"
-          echo "Total configs deleted: $total_deleted"
       
 
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -38,64 +38,6 @@ jobs:
             --max-results 100 \
             --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
             --output table       
-      - name: Delete old MQ configurations using pagination
-        run: |
-          set -e
-          retention_days=30
-          threshold_epoch=$(date -d "$retention_days days ago" +"%s")
-
-          count_total=0
-          count_deleted=0
-          page_token=""
-
-          echo "Scanning MQ configurations older than $retention_days days..."
-
-          while true; do
-            if [ -z "$page_token" ]; then
-              response=$(aws mq list-configurations --max-results 100 --output json)
-            else
-              response=$(aws mq list-configurations --max-results 100 --starting-token "$page_token" --output json)
-            fi
-
-            configs=$(echo "$response" | jq -c '.Configurations[]?')
-            page_token=$(echo "$response" | jq -r '.NextToken')
-
-            echo "$configs" | while read -r config; do
-              id=$(jq -r '.Id' <<< "$config")
-              name=$(jq -r '.Name' <<< "$config")
-              created=$(jq -r '.LatestRevision.Created' <<< "$config")
-
-              created_clean="${created%%.*}"
-              created_epoch=$(date -d "$created_clean" +"%s" 2>/dev/null || \
-                              date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
-
-              age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
-              count_total=$((count_total + 1))
-
-              # Check if attached to any broker
-              attached=$(aws mq list-brokers \
-                --query "BrokerSummaries[?Configuration.Id=='$id'].BrokerId" \
-                --output text)
-
-              if [ -n "$attached" ]; then
-                echo "In use, skipping: $name ($id) — broker: $attached"
-                continue
-              fi
-
-              if [ "$created_epoch" -lt "$threshold_epoch" ]; then
-                echo "🗑️ Deleting: $name ($id), created $age_days days ago"
-                count_deleted=$((count_deleted + 1))
-              else
-                echo "skipped: $name ($id), created $age_days days ago"
-              fi
-            done
-
-            [ "$page_token" == "null" ] || [ -z "$page_token" ] && break
-          done
-
-          echo "--------------------------------------------------"
-          echo "Total configurations checked: $count_total"
-          echo "Total configurations deleted: $count_deleted
       - name: Delete MQ 
         run: |
           retention_days=30
@@ -127,6 +69,66 @@ jobs:
 
           echo "delete count: $count"
           echo "skip count: $count_skip"
+      - name: Delete old MQ configurations (using pagination)
+        run: |
+          set -e
+          retention_days=30
+          threshold_epoch=$(date -d "$retention_days days ago" +"%s")
+
+          total_checked=0
+          total_deleted=0
+          next_token=""
+
+          echo "🔍 Checking for MQ configurations older than $retention_days days..."
+
+          while true; do
+            if [ -z "$next_token" ]; then
+              response=$(aws mq list-configurations --max-results 100 --output json)
+            else
+              response=$(aws mq list-configurations --max-results 100 --next-token "$next_token" --output json)
+            fi
+
+            configs=$(echo "$response" | jq -c '.Configurations[]?')
+            next_token=$(echo "$response" | jq -r '.NextToken')
+
+            echo "$configs" | while read -r config; do
+              id=$(jq -r '.Id' <<< "$config")
+              name=$(jq -r '.Name' <<< "$config")
+              created=$(jq -r '.LatestRevision.Created' <<< "$config")
+
+              created_clean="${created%%.*}"
+              created_epoch=$(date -d "$created_clean" +"%s" 2>/dev/null || \
+                              date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
+
+              age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
+              total_checked=$((total_checked + 1))
+
+              # Check if configuration is attached to a broker
+              attached=$(aws mq list-brokers \
+                --query "BrokerSummaries[?Configuration.Id=='$id'].BrokerId" \
+                --output text)
+
+              if [ -n "$attached" ]; then
+                echo "In use: $name ($id) — broker: $attached"
+                continue
+              fi
+
+              if [ "$created_epoch" -lt "$threshold_epoch" ]; then
+                echo "Deleting: $name ($id) — $age_days days old"
+                total_deleted=$((total_deleted + 1))
+              else
+                echo "Keeping: $name ($id) — $age_days days old"
+              fi
+            done
+
+            # Exit loop if no more pages
+            [ "$next_token" == "null" ] || [ -z "$next_token" ] && break
+          done
+
+          echo "--------------------------------------------------"
+          echo "Total configs checked: $total_checked"
+          echo "Total configs deleted: $total_deleted"
+      
 
 
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -38,36 +38,64 @@ jobs:
             --max-results 100 \
             --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
             --output table       
-      - name: Find and delete MQ configurations older than 30 days
+      - name: Delete old MQ configurations using pagination
         run: |
           set -e
-          echo "Fetching all MQ configurations..."
-          TOKEN=""
-          THRESHOLD_DATE=$(date -d "30 days ago" +%s)
-          COUNT=0
+          retention_days=30
+          threshold_epoch=$(date -d "$retention_days days ago" +"%s")
+
+          count_total=0
+          count_deleted=0
+          page_token=""
+
+          echo "Scanning MQ configurations older than $retention_days days..."
+
           while true; do
-            if [ -z "$TOKEN" ]; then
-              RESPONSE=$(aws mq list-configurations --max-results 100)
+            if [ -z "$page_token" ]; then
+              response=$(aws mq list-configurations --max-results 100 --output json)
             else
-              RESPONSE=$(aws mq list-configurations --max-results 100 --next-token "$TOKEN")
+              response=$(aws mq list-configurations --max-results 100 --starting-token "$page_token" --output json)
             fi
-            CONFIGS=$(echo "$RESPONSE" | jq -c '.Configurations[]')
-            for CONFIG in $CONFIGS; do
-              ID=$(echo "$CONFIG" | jq -r '.Id')
-              NAME=$(echo "$CONFIG" | jq -r '.Name')
-              DATE_PART=$(echo "$NAME" | grep -oE '[0-9]{8}' || true)
-              if [ -n "$DATE_PART" ]; then
-                CONFIG_DATE=$(date -d "${DATE_PART}" +%s 2>/dev/null || echo 0)
-                if [ "$CONFIG_DATE" -lt "$THRESHOLD_DATE" ]; then
-                  echo "Deleting old configuration: $NAME ($ID)"
-                  COUNT=$((COUNT + 1))
-                fi
+
+            configs=$(echo "$response" | jq -c '.Configurations[]?')
+            page_token=$(echo "$response" | jq -r '.NextToken')
+
+            echo "$configs" | while read -r config; do
+              id=$(jq -r '.Id' <<< "$config")
+              name=$(jq -r '.Name' <<< "$config")
+              created=$(jq -r '.LatestRevision.Created' <<< "$config")
+
+              created_clean="${created%%.*}"
+              created_epoch=$(date -d "$created_clean" +"%s" 2>/dev/null || \
+                              date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
+
+              age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
+              count_total=$((count_total + 1))
+
+              # Check if attached to any broker
+              attached=$(aws mq list-brokers \
+                --query "BrokerSummaries[?Configuration.Id=='$id'].BrokerId" \
+                --output text)
+
+              if [ -n "$attached" ]; then
+                echo "In use, skipping: $name ($id) — broker: $attached"
+                continue
+              fi
+
+              if [ "$created_epoch" -lt "$threshold_epoch" ]; then
+                echo "🗑️ Deleting: $name ($id), created $age_days days ago"
+                count_deleted=$((count_deleted + 1))
+              else
+                echo "skipped: $name ($id), created $age_days days ago"
               fi
             done
-            TOKEN=$(echo "$RESPONSE" | jq -r '.NextToken')
-            [ "$TOKEN" == "null" ] && break
+
+            [ "$page_token" == "null" ] || [ -z "$page_token" ] && break
           done
-          echo "Total MQ configurations deleted: $COUNT"
+
+          echo "--------------------------------------------------"
+          echo "Total configurations checked: $count_total"
+          echo "Total configurations deleted: $count_deleted
       - name: Delete MQ 
         run: |
           retention_days=30

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -27,7 +27,7 @@ jobs:
           aws-region: eu-west-1
       - name: Delete MQ 
         run: |
-          retention_days=30
+          retention_days=1000
           now=$(date -u +"%s")
 
           configs=$(aws mq list-configurations \
@@ -39,14 +39,15 @@ jobs:
             config_id=$(jq -r '.ID' <<< "$config")
             config_name=$(jq -r '.Name' <<< "$config")
             created=$(jq -r '.Created' <<< "$config")
-
-            # Convert created date to epoch (supports Linux/macOS)
+            
             created_epoch=$(date -d "$created" +"%s" 2>/dev/null || \
                             date -j -f "%Y-%m-%dT%H:%M:%S" "$(echo "$created" | cut -d. -f1)" +"%s")
             age_days=$(( (now - created_epoch) / 86400 ))
 
             if [ "$age_days" -gt "$retention_days" ]; then
               echo "Deleting configuration $config_name (ID: $config_id, Age: $age_days days)"
+              aws mq delete-configuration --configuration-id "$config_id"
+              break
             else
               echo "Skipping configuration $config_name (ID: $config_id, Age: $age_days days)"
             fi

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
-          aws-region: ${{ inputs.aws_region }}
+          aws-region: eu-west-1
           role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/alfresco-cloud-deploy
           role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: 5400    

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -28,5 +28,5 @@ jobs:
       - name: List MQ 
         run: |
           aws mq list-configurations \
-            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,EngineVersion]" \
+            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
             --output table

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -91,15 +91,16 @@ jobs:
             configs=$(echo "$response" | jq -c '.Configurations[]?')
             next_token=$(echo "$response" | jq -r '.NextToken')
 
-            echo "$configs" | while read -r config; do
+            while read -r config; do
               id=$(jq -r '.Id' <<< "$config")
               name=$(jq -r '.Name' <<< "$config")
+
               if [[ "$name" != molecule-* ]]; then
                 echo "Skipping: $name (ID: $id) — doesn't match prefix 'molecule-'"
                 continue
               fi
-              created=$(jq -r '.LatestRevision.Created' <<< "$config")
 
+              created=$(jq -r '.LatestRevision.Created' <<< "$config")
               created_clean="${created%%.*}"
               created_epoch=$(date -d "$created_clean" +"%s" 2>/dev/null || \
                               date -j -f "%Y-%m-%dT%H:%M:%S" "$created_clean" +"%s" || echo 0)
@@ -107,7 +108,6 @@ jobs:
               age_days=$(( ( $(date -u +"%s") - created_epoch ) / 86400 ))
               total_checked=$((total_checked + 1))
 
-              # Check if configuration is attached to a broker
               attached=$(aws mq list-brokers \
                 --query "BrokerSummaries[?Configuration.Id=='$id'].BrokerId" \
                 --output text)
@@ -120,16 +120,16 @@ jobs:
               if [ "$created_epoch" -lt "$threshold_epoch" ]; then
                 echo "Deleting: $name ($id) — $age_days days old"
                 total_deleted=$((total_deleted + 1))
-                echo "check number: $total_checked"
+
                 if [ "$total_deleted" -ge 20 ]; then
                   echo "deleted 20 records"
                   break 2
                 fi
-
               else
                 echo "Keeping: $name ($id) — $age_days days old"
               fi
-            done
+            done < <(echo "$configs")
+
 
             # Exit loop if no more pages
             [ "$next_token" == "null" ] || [ -z "$next_token" ] && break

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -35,15 +35,14 @@ jobs:
           configs=$(aws mq list-configurations \
             --no-paginate \
             --query "Configurations[?starts_with(Name, 'molecule-')].{ID:Id, Name:Name, Created:LatestRevision.Created}" \
-            --output json)
-
-          echo "$configs" | jq -c '.[]' | while read -r config; do
+            --output json)          
+          while read -r config; do
             config_id=$(jq -r '.ID' <<< "$config")
             config_name=$(jq -r '.Name' <<< "$config")
             created=$(jq -r '.Created' <<< "$config")
 
-            created_epoch=$(date -d "$created" +"%s" 2>/dev/null || \
-                            date -j -f "%Y-%m-%dT%H:%M:%S" "$(echo "$created" | cut -d. -f1)" +"%s")
+            created_epoch=$(date -d "${created%%.*}" +"%s" 2>/dev/null || \
+                            date -j -f "%Y-%m-%dT%H:%M:%S" "${created%%.*}" +"%s")
             age_days=$(( (now - created_epoch) / 86400 ))
 
             if [ "$age_days" -gt "$retention_days" ]; then
@@ -53,9 +52,11 @@ jobs:
               echo "Skipping configuration $config_name (ID: $config_id, Age: $age_days days)"
               count_skip=$((count_skip + 1))
             fi
-          done
-          echo "delete count $count"
-          echo "skip count $count_skip"
+          done < <(echo "$configs" | jq -c '.[]')
+
+          echo "delete count: $count"
+          echo "skip count: $count_skip"
+
 
 
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -31,6 +31,7 @@ jobs:
           now=$(date -u +"%s")
 
           configs=$(aws mq list-configurations \
+            --no-paginate \
             --query "Configurations[?starts_with(Name, 'molecule-')].{ID:Id, Name:Name, Created:LatestRevision.Created}" \
             --output json)
 

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -38,6 +38,36 @@ jobs:
             --max-results 100 \
             --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
             --output table       
+      - name: Find and delete MQ configurations older than 30 days
+        run: |
+          set -e
+          echo "Fetching all MQ configurations..."
+          TOKEN=""
+          THRESHOLD_DATE=$(date -d "30 days ago" +%s)
+          COUNT=0
+          while true; do
+            if [ -z "$TOKEN" ]; then
+              RESPONSE=$(aws mq list-configurations --max-results 100)
+            else
+              RESPONSE=$(aws mq list-configurations --max-results 100 --next-token "$TOKEN")
+            fi
+            CONFIGS=$(echo "$RESPONSE" | jq -c '.Configurations[]')
+            for CONFIG in $CONFIGS; do
+              ID=$(echo "$CONFIG" | jq -r '.Id')
+              NAME=$(echo "$CONFIG" | jq -r '.Name')
+              DATE_PART=$(echo "$NAME" | grep -oE '[0-9]{8}' || true)
+              if [ -n "$DATE_PART" ]; then
+                CONFIG_DATE=$(date -d "${DATE_PART}" +%s 2>/dev/null || echo 0)
+                if [ "$CONFIG_DATE" -lt "$THRESHOLD_DATE" ]; then
+                  echo "Deleting old configuration: $NAME ($ID)"
+                  COUNT=$((COUNT + 1))
+                fi
+              fi
+            done
+            TOKEN=$(echo "$RESPONSE" | jq -r '.NextToken')
+            [ "$TOKEN" == "null" ] && break
+          done
+          echo "Total MQ configurations deleted: $COUNT"
       - name: Delete MQ 
         run: |
           retention_days=30

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -1,7 +1,10 @@
 name: Delete MQ Configurations
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - OPSEXP-3170
+  workflow_dispatch:  
 
 jobs:
   delete-mq-configs:

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -12,14 +12,19 @@ jobs:
   delete-mq-configs:
     runs-on: ubuntu-latest
     steps:
-      - name: Login to AWS
+      # - name: Login to AWS
+      #   uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+      #   with:
+      #     aws-region: eu-west-1
+      #     role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/alfresco-cloud-deploy
+      #     role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
+      #     role-duration-seconds: 5400    
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
+          aws-access-key-id: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_SECRET_ACCESS_KEY}}
           aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::372466110691:role/AlfrescoCI/alfresco-cloud-deploy
-          role-session-name: ${{ github.event.repository.name }}-${{ github.run_id }}
-          role-duration-seconds: 5400    
-
       - name: List MQ 
         run: |
           aws mq list-configurations \

--- a/.github/workflows/delete-mq-configs.yml
+++ b/.github/workflows/delete-mq-configs.yml
@@ -25,6 +25,19 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_ANSIBLE_MANAGED_SERVICE_DEV_SECRET_ACCESS_KEY}}
           aws-region: eu-west-1
+      - name: List MQ 
+        run: |
+          aws mq list-configurations \
+            --no-paginate \
+            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,EngineVersion]" \
+            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
+            --output table  
+      - name: Test Pagination for MQ Configurations
+        run: |
+          aws mq list-configurations \
+            --max-items 100 \
+            --query "Configurations[?starts_with(Name, 'molecule-')].[Id,Name,EngineType,Created,LatestRevision.Created,EngineVersion]" \
+            --output table       
       - name: Delete MQ 
         run: |
           retention_days=30


### PR DESCRIPTION
### Related Issue
OPSEXP-3170 
### Summary
This PR introduces a GitHub Action to automatically clean up AWS MQ configurations that:
- Have the name prefix `molecule-`
- Are older than 30 days based on their creation timestamp
- Are not currently attached to any active brokers
- Schedules to run on 1st of every month

#### Note: 
We are using **.LatestRevision.Created** field to check the age and take delete accordingly.