### PR TITLE
simplify cache key definition in cache-downloads action

### DIFF
--- a/.github/actions/cache-downloads/action.yml
+++ b/.github/actions/cache-downloads/action.yml
@@ -29,9 +29,10 @@ runs:
       uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: 'downloads/**'
-        key: "cache-downloads-v${{ inputs.cache-version }}-${{ inputs.cache-name }}-\
-          mq${{ steps.activemq_peek.outputs.activemq_version }}-\
-          tc${{ steps.tomcat_peek.outputs.tomcat_version }}-\
+        key: >-
+          cache-downloads-v${{ inputs.cache-version }}-${{ inputs.cache-name }}-
+          mq${{ steps.activemq_peek.outputs.activemq_version }}-
+          tc${{ steps.tomcat_peek.outputs.tomcat_version }}-
           ${{ hashFiles('.github/actions/cache-downloads/prefetch-artifacts.yml') }}"
 
     - name: Prefetch artifacts

--- a/.github/actions/cache-downloads/action.yml
+++ b/.github/actions/cache-downloads/action.yml
@@ -33,7 +33,7 @@ runs:
           cache-downloads-v${{ inputs.cache-version }}-${{ inputs.cache-name }}-
           mq${{ steps.activemq_peek.outputs.activemq_version }}-
           tc${{ steps.tomcat_peek.outputs.tomcat_version }}-
-          ${{ hashFiles('.github/actions/cache-downloads/prefetch-artifacts.yml') }}"
+          ${{ hashFiles('.github/actions/cache-downloads/prefetch-artifacts.yml') }}
 
     - name: Prefetch artifacts
       shell: bash


### PR DESCRIPTION
just a guess at fixing https://github.com/Alfresco/alfresco-ansible-deployment/actions/runs/16749955596/job/47417431204#step:3:170

it's the only unusual thing we have in this action