### PR TITLE
Relax dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 2
     ignore:
       - dependency-name: "boto3"
       - dependency-name: "ansible-core"
         update-types: ["version-update:semver-minor"]
-    groups:
-      molecule:
-        patterns:
-          - "molecule"
-          - "molecule-plugins"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
* Removes the PR limit
* Drop the molecule group which currently can't be updated due to roles using relative paths