### PR TITLE
OPSEXP-4055: Add alfresco-pdf-renderer to the updatecli maven pipeline

### DIFF
--- a/.github/updatecli/updatecli_maven_roles_values.yml
+++ b/.github/updatecli/updatecli_maven_roles_values.yml
@@ -36,7 +36,7 @@ artifacts:
     artifact_name_key: $.transformers_pdf_artifact_name
     artifact_version_key: $.transformers_pdf_version
     ansible_version_file: roles/transformers/defaults/main.yml
-    updatecli_matrix_component_key: alfresco-pdf-renderer
+    updatecli_matrix_component_key: pdf-renderer
   alfresco-transform-router:
     artifact_name_file: roles/trouter/defaults/main.yml
     artifact_name_key: $.trouter_artifact_name

--- a/.github/updatecli/updatecli_maven_roles_values.yml
+++ b/.github/updatecli/updatecli_maven_roles_values.yml
@@ -36,7 +36,7 @@ artifacts:
     artifact_name_key: $.transformers_pdf_artifact_name
     artifact_version_key: $.transformers_pdf_version
     ansible_version_file: roles/transformers/defaults/main.yml
-    updatecli_matrix_component_key: tengine-aio
+    updatecli_matrix_component_key: alfresco-pdf-renderer
   alfresco-transform-router:
     artifact_name_file: roles/trouter/defaults/main.yml
     artifact_name_key: $.trouter_artifact_name

--- a/.github/updatecli/updatecli_maven_roles_values.yml
+++ b/.github/updatecli/updatecli_maven_roles_values.yml
@@ -31,6 +31,12 @@ artifacts:
     artifact_version_key: $.transformers_aio_version
     ansible_version_file: roles/transformers/defaults/main.yml
     updatecli_matrix_component_key: tengine-aio
+  alfresco-pdf-renderer:
+    artifact_name_file: roles/transformers/defaults/main.yml
+    artifact_name_key: $.transformers_pdf_artifact_name
+    artifact_version_key: $.transformers_pdf_version
+    ansible_version_file: roles/transformers/defaults/main.yml
+    updatecli_matrix_component_key: tengine-aio
   alfresco-transform-router:
     artifact_name_file: roles/trouter/defaults/main.yml
     artifact_name_key: $.trouter_artifact_name

--- a/.github/updatecli/updatecli_maven_values.yml
+++ b/.github/updatecli/updatecli_maven_values.yml
@@ -63,3 +63,8 @@ artifacts:
     artifact_name_key: $.acs_play_sfs_artifact_name
     artifact_version_key: $.acs_play_sfs_version
     updatecli_matrix_component_key: sfs
+  alfresco-pdf-renderer:
+    artifact_name_file: playbooks/group_vars/transformers.yml
+    artifact_name_key: $.acs_play_transformers_pdf_artifact_name
+    artifact_version_key: $.acs_play_transformers_pdf_version
+    updatecli_matrix_component_key: pdf-renderer

--- a/roles/transformers/defaults/main.yml
+++ b/roles/transformers/defaults/main.yml
@@ -26,7 +26,7 @@ transformers_libreoffice_home: "/opt/libreoffice{{ transformers_libreoffice_vers
 transformers_pdf_artifact_name: alfresco-pdf-renderer
 transformers_pdf_repository: https://artifacts.alfresco.com/nexus/content/groups/public/org/alfresco
 
-transformers_pdf_version: 1.1
+transformers_pdf_version: 1.3.0-76
 transformers_pdf_archive_name: "{{ transformers_pdf_artifact_name }}-{{ transformers_pdf_version }}-linux.tgz"
 transformers_pdf_archive_url: "{{ transformers_pdf_repository }}/{{ transformers_pdf_artifact_name }}/{{ transformers_pdf_version }}/{{ transformers_pdf_archive_name }}"
 transformers_pdf_archive_checksum: "sha1:{{ transformers_pdf_archive_url }}.sha1"

--- a/vars/acs23.yml
+++ b/vars/acs23.yml
@@ -33,7 +33,7 @@ acs_play_sync_version: 5.3.2
 acs_play_tomcat_version: 10.1.54
 acs_play_trouter_version: 4.4.1
 acs_play_transformers_libreoffice_version: 7.2.5.1
-acs_play_transformers_pdf_version: 1.1
+acs_play_transformers_pdf_version: 1.3.0-76
 acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
 acs_play_transformers_aio_version: 5.4.1
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"

--- a/vars/acs25.yml
+++ b/vars/acs25.yml
@@ -39,9 +39,9 @@ acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
 acs_play_transformers_aio_version: 5.4.1
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 16
-acs_play_repository_acs_version: 25.3.7
+acs_play_repository_acs_version: 25.3.2
 acs_play_repository_api_explorer_version: 25.3.0
 acs_play_repository_amp_googledrive_repo_version: 4.1.0
 acs_play_repository_amp_googledrive_share_version: 4.1.0
-acs_play_repository_amp_device_sync_version: 5.3.0
-acs_play_repository_amp_aos_module_version: 3.4.0
+acs_play_repository_amp_device_sync_version: 5.3.1
+acs_play_repository_amp_aos_module_version: 3.4.1

--- a/vars/acs25.yml
+++ b/vars/acs25.yml
@@ -34,14 +34,14 @@ acs_play_sync_version: 5.3.2
 acs_play_tomcat_version: 10.1.54
 acs_play_trouter_version: 4.4.1
 acs_play_transformers_libreoffice_version: 7.2.5.1
-acs_play_transformers_pdf_version: 1.1
+acs_play_transformers_pdf_version: 1.3.0-76
 acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
 acs_play_transformers_aio_version: 5.4.1
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 16
-acs_play_repository_acs_version: 25.3.2
+acs_play_repository_acs_version: 25.3.7
 acs_play_repository_api_explorer_version: 25.3.0
 acs_play_repository_amp_googledrive_repo_version: 4.1.0
 acs_play_repository_amp_googledrive_share_version: 4.1.0
-acs_play_repository_amp_device_sync_version: 5.3.1
-acs_play_repository_amp_aos_module_version: 3.4.1
+acs_play_repository_amp_device_sync_version: 5.3.0
+acs_play_repository_amp_aos_module_version: 3.4.0

--- a/vars/acs26.yml
+++ b/vars/acs26.yml
@@ -34,7 +34,7 @@ acs_play_sync_version: 5.3.2
 acs_play_tomcat_version: 11.0.21
 acs_play_trouter_version: 4.4.1
 acs_play_transformers_libreoffice_version: 7.2.5.1
-acs_play_transformers_pdf_version: 1.1
+acs_play_transformers_pdf_version: 1.3.0-76
 acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
 acs_play_transformers_aio_version: 5.4.1
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"

--- a/vars/acs74.yml
+++ b/vars/acs74.yml
@@ -28,7 +28,7 @@ acs_play_sync_version: 3.11.3
 acs_play_tomcat_version: 9.0.117
 acs_play_trouter_version: 4.4.1
 acs_play_transformers_libreoffice_version: 7.2.5.1
-acs_play_transformers_pdf_version: 1.1
+acs_play_transformers_pdf_version: 1.3.0-76
 acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
 acs_play_transformers_aio_version: 5.4.1
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"


### PR DESCRIPTION
Ref: OPSEXP-4055

Requires: https://github.com/Alfresco/alfresco-updatecli/pull/92