### PR TITLE
OPSEXP-4095 Update support.hyland.com and docs.alfresco.com references to docs.hyland.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Follow the checklist:
 
 1. Review currently open dependabot/renovate and merge them.
 2. For minor releases, ensure to update the links beginning with
-  `https://support.hyland.com/r/Alfresco` to reflect the latest version or
+  `https://docs.hyland.com/p/alfresco` to reflect the latest version or
   corresponding minor update documentation.
 3. In case of a new ACS major version, create new vars/acsXX.yml file. Remember to move community related vars to the new file.
 4. Always check the no changes are left under the "Unreleased version" section

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -67,4 +67,4 @@ repository_acs_environment:
 
 `metadata-keystore.metadata.password` is the password of the keystore dedicated to repository metadata.
 
-[security]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization
+[security]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,8 +6,8 @@ color_scheme: alfresco
 url: https://alfresco.github.io
 
 aux_links:
-  Hyland Support: https://support.hyland.com/p/alfresco
-  Legacy Docs: https://docs.alfresco.com/
+  Hyland Support: https://docs.hyland.com/p/alfresco
+  Legacy Docs: https://docs.hyland.com/
   GitHub Repository: https://github.com/Alfresco/alfresco-ansible-deployment
 
 aux_links_new_tab: true

--- a/docs/components-upgrade.md
+++ b/docs/components-upgrade.md
@@ -111,4 +111,4 @@ This process will restart tomcat on all the repository nodes and there is no
 guarantee one node is stopped only after the others have restarted. As a
 consequence a short service outage needs to be scheduled
 
-[acs-upgrade]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Upgrade
+[acs-upgrade]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Upgrade

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1363,9 +1363,9 @@ If the playbook fails for some reason try re-running it with the `-v` option, if
 
 If the playbook completes successfully but the system is not functioning the best place to start is the log files, these can be found in the `/var/log/alfresco` folder on the target hosts. Please note the nginx log files are owned by root as the nginx process is running as root so it can listen on port 80.
 
-[upload-license]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Licenses/Upload-a-new-license
-[global-properties]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Overview/Using-alfresco-global.properties
-[databases]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Databases
-[alf-keystores]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization/Manage-Alfresco-keystores
-[keystore-generation]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization/Manage-Alfresco-keystores/Keystore-generation
-[redundancy]: https://support.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/High-availability-features/Clustering/Recommendations-for-split-architecture/Scenario-Clustering-for-redundancy
+[upload-license]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Licenses/Upload-a-new-license
+[global-properties]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Overview/Using-alfresco-global.properties
+[databases]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Configure/Databases
+[alf-keystores]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization/Manage-Alfresco-keystores
+[keystore-generation]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/Manage-Security/Authorization/Manage-Alfresco-keystores/Keystore-generation
+[redundancy]: https://docs.hyland.com/r/Alfresco/Alfresco-Content-Services/26.1/Alfresco-Content-Services/Administer/High-availability-features/Clustering/Recommendations-for-split-architecture/Scenario-Clustering-for-redundancy

--- a/docs/hxi-deployment.md
+++ b/docs/hxi-deployment.md
@@ -12,7 +12,7 @@ learning to your content repository.
 
 You can get the most up-to-date product documentation for the `Alfresco
 Connector` in the [Content Intelligence
-Documentation](https://support.hyland.com/p/contentintel).
+Documentation](https://docs.hyland.com/p/contentintel).
 
 ## Prerequisites
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -116,4 +116,4 @@ ACS 7.x onward.
 > Support for ACS 7.0 has been deprecated since April 2024, but you can still use the latest playbook that supported it ([v2.6.0](https://github.com/Alfresco/alfresco-ansible-deployment/releases/tag/v2.6.0))
 > Support for ACS 6.2 has been deprecated since November 2022, but you can still use the latest playbook that supported it ([v2.2.0](https://github.com/Alfresco/alfresco-ansible-deployment/releases/tag/v2.2.0))
 
-[support]: https://support.hyland.com/r/Current/Alfresco-Supported-Platforms/Part-2-Platform-Compatibility
+[support]: https://docs.hyland.com/r/Current/Alfresco-Supported-Platforms/Part-2-Platform-Compatibility

--- a/roles/search_enterprise/defaults/main.yml
+++ b/roles/search_enterprise/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for search_enterprise
 search_enterprise_port: 8081
-# see https://support.hyland.com/r/Alfresco/Alfresco-Search-Enterprise/5.4/Alfresco-Search-Enterprise/Administer
+# see https://docs.hyland.com/r/Alfresco/Alfresco-Search-Enterprise/5.4/Alfresco-Search-Enterprise/Administer
 search_enterprise_reindex_options: ''
 
 search_enterprise_artifact_name: alfresco-elasticsearch-connector-distribution


### PR DESCRIPTION
[OPSEXP-4095](https://hyland.atlassian.net/browse/OPSEXP-4095)
Updated documentation references to use the consolidated Hyland documentation portal:

Replaced https://support.hyland.com/
Replaced https://docs.alfresco.com/

with: https://docs.hyland.com/

[OPSEXP-4095]: https://hyland.atlassian.net/browse/OPSEXP-4095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ