### PR TITLE
OPSEXP-4157 Move nginx Alfresco logs to /var/log/nginx to satisfy SELinux and out-of-box rotation

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -8,6 +8,12 @@ nginx_vhosts:
 nginx_use_ssl: false
 nginx_fqdn_alfresco: ""
 
+# On SELinux-enabled nodes nginx (httpd_t) may only write logs labelled
+# httpd_log_t, so /var/log/nginx is the only allowed location.
+nginx_logs_folder: /var/log/nginx
+nginx_access_log: "{{ nginx_logs_folder }}/alfresco.access.log"
+nginx_error_log: "{{ nginx_logs_folder }}/alfresco.error.log"
+
 # role arguments defaults
 nginx_setup_service: true
 nginx_setup_vhosts: true

--- a/roles/nginx/templates/alfresco.conf.j2
+++ b/roles/nginx/templates/alfresco.conf.j2
@@ -30,8 +30,8 @@ upstream share_lb {
     }
 
 server {
-    access_log {{ logs_folder }}/nginx.alfresco.access.log;
-    error_log  {{ logs_folder }}/nginx.alfresco.error.log error;
+    access_log {{ nginx_access_log }};
+    error_log  {{ nginx_error_log }} error;
 
     listen {{ item.listen | default('80') }}{% if item.listen == '443' %} ssl{% endif %};
 {% if item.server_name is defined %}

--- a/roles/nginx/templates/alfresco_redirect.conf.j2
+++ b/roles/nginx/templates/alfresco_redirect.conf.j2
@@ -8,8 +8,8 @@ map $remote_addr $rogue_repo_clients {
 }
 
 server {
-    access_log {{ logs_folder }}/nginx.alfresco.access.log;
-    error_log  {{ logs_folder }}/nginx.alfresco.error.log error;
+    access_log {{ nginx_access_log }};
+    error_log  {{ nginx_error_log }} error;
 
     listen {{ ports_cfg.nginx.http | default('80') }};
 


### PR DESCRIPTION
The reverse-proxy vhosts wrote their access/error logs under /var/log/alfresco, which the common role labels with the SELinux type var_log_t. nginx runs in the httpd_t domain, which is only allowed to open httpd_log_t files, so on SELinux-enabled nodes nginx is denied (avc: denied { open }) and fails to (re)start. The nginx master process opens the logs as root, so the standard permissions without selinux are quitly bypassed.

Point the logs at /var/log/nginx instead, which is httpd_log_t by default and the only location nginx is allowed to write. The paths are now defined once via nginx_access_log / nginx_error_log to avoid duplication across the two vhost templates, and the redundant "nginx." filename prefix is dropped. Files still end in .log so they remain covered by the nginx package's logrotate.

OPSEXP-4157