### PR TITLE
OPSEXP-4247 Test alternate nexus-archive artifact repository

### DIFF
--- a/.github/workflows/enteprise.yml
+++ b/.github/workflows/enteprise.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check if nexus secrets are available
         id: check-secrets
         run: | # pragma: allowlist secret
-          if [ -z "${{ secrets.nexus_username }}" ] || [-z "${{ secrets.nexus_password }}"]; then
+          if [ -z "${{ secrets.NEXUS_ARCHIVE_USERNAME }}" ] || [-z "${{ secrets.NEXUS_ARCHIVE_PASSWORD }}"]; then
             echo "nexus_username or nexus_password is missing"
             echo "secrets-available=false" >> $GITHUB_OUTPUT
             exit 0
@@ -128,8 +128,8 @@ jobs:
       - name: Run tests
         env:
           MOLECULE_ROLE_IMAGE: ${{ matrix.molecule_distro.image }}
-          NEXUS_USERNAME: ${{ secrets.nexus_username }}
-          NEXUS_PASSWORD: ${{ secrets.nexus_password }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_ARCHIVE_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_ARCHIVE_PASSWORD }}
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 60
@@ -176,8 +176,8 @@ jobs:
       runner: ${{ matrix.runner }}
       gh_app_client_id: ${{ vars.GH_APP_ENGINEERING_RO_CLIENT_ID }}
     secrets:
-      nexus_username: ${{ secrets.NEXUS_USERNAME_READ_ONLY }}
-      nexus_password: ${{ secrets.NEXUS_PASSWORD_READ_ONLY }}
+      nexus_username: ${{ secrets.NEXUS_ARCHIVE_USERNAME }}
+      nexus_password: ${{ secrets.NEXUS_ARCHIVE_PASSWORD }}
       gh_app_private_key: ${{ secrets.GH_APP_ENGINEERING_RO_PRIVATE_KEY }}
 
   ec2:
@@ -241,7 +241,7 @@ jobs:
           matrix_name: ${{ matrix.molecule_scenario.name }}
           matrix_vars: ${{ matrix.molecule_scenario.vars }}
           matrix_desc: ${{ matrix.molecule_scenario.desc }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME_READ_ONLY }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD_READ_ONLY }}
+          nexus_username: ${{ secrets.NEXUS_ARCHIVE_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_ARCHIVE_PASSWORD }}
           aws_region: ${{ env.AWS_REGION }}
           pat: ${{ steps.app-token-dtas.outputs.token }}

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -833,7 +833,7 @@
     - role: alfresco.platform.cic_connector
       cic_connector_artifact_username: "{{ nexus_user }}"
       cic_connector_artifact_password: "{{ nexus_password }}"
-      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases }}/"
+      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases }}"
       cic_connector_java_home_path: "/opt/openjdk-{{ acs_play_java_core }}"
       cic_connector_artifact_default_version: "{{ acs_play_cic_connector_version }}"
       cic_connector_live_ingester_port: "{{ acs_play_cic_connector_live_ingester_port }}"

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -574,7 +574,7 @@
       search_community_java_bin_path: "/opt/openjdk-{{ acs_play_java_core }}/bin/java"
       search_community_version: "{{ acs_play_search_community_version }}"
       search_community_artifact_name: "{{ acs_play_search_community_artifact_name }}"
-      search_community_repository: "{{ acs_play_search_community_repository }}"
+      search_community_repository_url: "{{ acs_play_search_community_repository }}"
       search_community_zip_url: "{{ acs_play_search_community_zip_url }}"
       search_community_zip_checksum: "{{ acs_play_search_community_zip_checksum }}"
       search_community_username: "{{ username }}"

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -833,7 +833,7 @@
     - role: alfresco.platform.cic_connector
       cic_connector_artifact_username: "{{ nexus_user }}"
       cic_connector_artifact_password: "{{ nexus_password }}"
-      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases_repository }}"
+      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases }}/"
       cic_connector_java_home_path: "/opt/openjdk-{{ acs_play_java_core }}"
       cic_connector_artifact_default_version: "{{ acs_play_cic_connector_version }}"
       cic_connector_live_ingester_port: "{{ acs_play_cic_connector_live_ingester_port }}"

--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -833,6 +833,7 @@
     - role: alfresco.platform.cic_connector
       cic_connector_artifact_username: "{{ nexus_user }}"
       cic_connector_artifact_password: "{{ nexus_password }}"
+      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases_repository }}"
       cic_connector_java_home_path: "/opt/openjdk-{{ acs_play_java_core }}"
       cic_connector_artifact_default_version: "{{ acs_play_cic_connector_version }}"
       cic_connector_live_ingester_port: "{{ acs_play_cic_connector_live_ingester_port }}"

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -9,11 +9,11 @@ acs_play_default_java_version: 17.0.19+10
 
 artifacts_repositories:
   enterprise:
-    base_url: "https://nexus-archive.opsexp.alfresco.com"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com"
     repository: "groups/private"
     group_id: "org/alfresco"
   community:
-    base_url: "https://nexus-archive.opsexp.alfresco.com"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com"
     repository: "groups/public"
     group_id: "org/alfresco"
   development:

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -7,15 +7,13 @@ acs_play_major_version: 26
 
 acs_play_default_java_version: 17.0.19+10
 
-nexus_host: "https://nexus-archive2.opsexp.alfresco.com"
-
 artifacts_repositories:
   enterprise:
-    base_url: "{{ nexus_host }}/nexus/content"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
     repository: "groups/private"
     group_id: "org/alfresco"
   community:
-    base_url: "{{ nexus_host }}/nexus/content"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
     repository: "groups/public"
     group_id: "org/alfresco"
   development:
@@ -27,7 +25,6 @@ nexus_repository:
     {{ artifacts_repositories.enterprise.base_url }}/{{ artifacts_repositories.enterprise.repository }}/{{ artifacts_repositories.enterprise.group_id }}
   development_releases: >-
     {{ artifacts_repositories.enterprise.base_url }}/{{ artifacts_repositories.development.repository }}/{{ artifacts_repositories.enterprise.group_id }}
-  enterprise_releases_repository: "{{ nexus_host }}/nexus/repository/enterprise-releases/"
 
 acs_play_java_core: "{{ acs_play_java_version.split('+')[0] }}"
 acs_play_java_major: "{{ acs_play_java_core.split('.')[0] }}"

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -7,13 +7,15 @@ acs_play_major_version: 26
 
 acs_play_default_java_version: 17.0.19+10
 
+nexus_host: "https://nexus-archive2.opsexp.alfresco.com"
+
 artifacts_repositories:
   enterprise:
-    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
+    base_url: "{{ nexus_host }}/nexus/content"
     repository: "groups/private"
     group_id: "org/alfresco"
   community:
-    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
+    base_url: "{{ nexus_host }}/nexus/content"
     repository: "groups/public"
     group_id: "org/alfresco"
   development:
@@ -25,6 +27,7 @@ nexus_repository:
     {{ artifacts_repositories.enterprise.base_url }}/{{ artifacts_repositories.enterprise.repository }}/{{ artifacts_repositories.enterprise.group_id }}
   development_releases: >-
     {{ artifacts_repositories.enterprise.base_url }}/{{ artifacts_repositories.development.repository }}/{{ artifacts_repositories.enterprise.group_id }}
+  enterprise_releases_repository: "{{ nexus_host }}/nexus/repository/enterprise-releases/"
 
 acs_play_java_core: "{{ acs_play_java_version.split('+')[0] }}"
 acs_play_java_major: "{{ acs_play_java_core.split('.')[0] }}"

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -9,11 +9,11 @@ acs_play_default_java_version: 17.0.19+10
 
 artifacts_repositories:
   enterprise:
-    base_url: "https://nexus-archive2.opsexp.alfresco.com"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
     repository: "groups/private"
     group_id: "org/alfresco"
   community:
-    base_url: "https://nexus-archive2.opsexp.alfresco.com"
+    base_url: "https://nexus-archive2.opsexp.alfresco.com/nexus/content"
     repository: "groups/public"
     group_id: "org/alfresco"
   development:

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -9,11 +9,11 @@ acs_play_default_java_version: 17.0.19+10
 
 artifacts_repositories:
   enterprise:
-    base_url: "https://artifacts.alfresco.com/nexus/content"
+    base_url: "https://nexus-archive.opsexp.alfresco.com"
     repository: "groups/private"
     group_id: "org/alfresco"
   community:
-    base_url: "https://artifacts.alfresco.com/nexus/content"
+    base_url: "https://nexus-archive.opsexp.alfresco.com"
     repository: "groups/public"
     group_id: "org/alfresco"
   development:

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@ collections:
   # Alternate source for alfresco.platform
   - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
     type: git
-    version: 82a347658dd1ec666d045dc459fddf15c26db672 # pragma: allowlist secret
+    version: c901240bb82203232d1a538bd030a6f4da1695ab # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@ collections:
   # Alternate source for alfresco.platform
   - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
     type: git
-    version: 96841ba3f4fc1b2177a4c999373d90fc7bf43fbd # pragma: allowlist secret
+    version: 83ecc4df06ebe7772ece4e9c5c1faca3e26e56c5 # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@ collections:
   # Alternate source for alfresco.platform
   - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
     type: git
-    version: 83ecc4df06ebe7772ece4e9c5c1faca3e26e56c5 # pragma: allowlist secret
+    version: ecb3e6427da656c58c4a0ccc8f3cb2c581016576 # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@ collections:
   # Alternate source for alfresco.platform
   - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
     type: git
-    version: 5ca9ea2042d4864c210e1cba583e4dd4d9fb1f2e # pragma: allowlist secret
+    version: 82a347658dd1ec666d045dc459fddf15c26db672 # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,7 +23,7 @@ collections:
   # Alternate source for alfresco.platform
   - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
     type: git
-    version: ecb3e6427da656c58c4a0ccc8f3cb2c581016576 # pragma: allowlist secret
+    version: 5ca9ea2042d4864c210e1cba583e4dd4d9fb1f2e # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,12 +18,12 @@ collections:
     version: 11.4.0
   - name: community.aws
     version: 11.1.0
-  - name: alfresco.platform
-    version: 0.5.0
+  # - name: alfresco.platform
+  #   version: 0.5.0
   # Alternate source for alfresco.platform
-  # - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
-  #   type: git
-  #   version: 1c69453df2d140ae36df5e0e6d67b284c018aeda # pragma: allowlist secret
+  - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
+    type: git
+    version: 96841ba3f4fc1b2177a4c999373d90fc7bf43fbd # pragma: allowlist secret
 
 roles:
   - name: geerlingguy.elasticsearch


### PR DESCRIPTION
Points enterprise and community artifact downloads at the alternate nexus-archive2 Nexus mirror instead of artifacts.alfresco.com, and renames the CI secrets used to authenticate against it to `NEXUS_ARCHIVE_USERNAME`/`NEXUS_ARCHIVE_PASSWORD`. Also adds the missing `cic_connector_artifact_repository_url` override (reusing the existing `nexus_repository.enterprise_releases`) so the `cic_connector` role (from alfresco-ansible-collection) resolves against the same archive host instead of falling back to its own hardcoded default, matching how `audit_storage` and `search_community` were already wired.

Companion change in alfresco-ansible-collection: https://github.com/Alfresco/alfresco-ansible-collection/pull/68 (updates that repo's role defaults from nexus.alfresco.com to artifacts.alfresco.com, and reworks cic_connector's repository URL variable so it can be overridden with a group-aggregator style base without producing a duplicated path).

OPSEXP-4247