### PR TITLE
OPSEXP-4247 Wire molecule tests to the group_vars artifact repository

### DIFF
--- a/roles/activemq/molecule/default/molecule.yml
+++ b/roles/activemq/molecule/default/molecule.yml
@@ -34,3 +34,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/adf_app/molecule/default/converge.yml
+++ b/roles/adf_app/molecule/default/converge.yml
@@ -4,10 +4,10 @@
   vars:
     acc_v: 10.3.0
     acc_id: alfresco-control-center
-    acc_repo: https://artifacts.alfresco.com/nexus/content/groups/public/org/alfresco
+    acc_repo: "{{ acc_repository }}"
     adw_v: 7.3.0
     adw_id: alfresco-digital-workspace
-    adw_repo: https://artifacts.alfresco.com/nexus/content/groups/private/org/alfresco
+    adw_repo: "{{ adw_repository }}"
   tasks:
     - name: "Install alfresco-digital-workspace"
       vars:

--- a/roles/adf_app/molecule/default/molecule.yml
+++ b/roles/adf_app/molecule/default/molecule.yml
@@ -20,5 +20,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/adf_app/molecule/default/molecule.yml
+++ b/roles/adf_app/molecule/default/molecule.yml
@@ -13,6 +13,9 @@ platforms:
       - /run
       - /run/lock
       - /tmp
+    groups:
+      - adw
+      - acc
 provisioner:
   name: ansible
   env:

--- a/roles/audit_storage/defaults/main.yml
+++ b/roles/audit_storage/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for audit_storage
 audit_storage_version: 1.3.3
-audit_storage_zip_url: https://nexus.alfresco.com/nexus/repository/enterprise-releases/org/alfresco/alfresco-audit-storage-distribution/{{ audit_storage_version }}/alfresco-audit-storage-distribution-{{ audit_storage_version }}.zip
+audit_storage_zip_url: https://artifacts.alfresco.com/nexus/repository/enterprise-releases/org/alfresco/alfresco-audit-storage-distribution/{{ audit_storage_version }}/alfresco-audit-storage-distribution-{{ audit_storage_version }}.zip
 audit_storage_zip_checksum: sha1:{{ audit_storage_zip_url }}.sha1
 
 audit_storage_download_artifact_name: alfresco-audit-storage-app

--- a/roles/audit_storage/defaults/main.yml
+++ b/roles/audit_storage/defaults/main.yml
@@ -1,8 +1,11 @@
 ---
 # defaults file for audit_storage
+audit_storage_artifact_name: alfresco-audit-storage-distribution
+audit_storage_repository: https://artifacts.alfresco.com/nexus/content/groups/private/org/alfresco
+
 audit_storage_version: 1.3.3
-audit_storage_zip_url: https://artifacts.alfresco.com/nexus/repository/enterprise-releases/org/alfresco/alfresco-audit-storage-distribution/{{ audit_storage_version }}/alfresco-audit-storage-distribution-{{ audit_storage_version }}.zip
-audit_storage_zip_checksum: sha1:{{ audit_storage_zip_url }}.sha1
+audit_storage_zip_url: "{{ audit_storage_repository }}/{{ audit_storage_artifact_name }}/{{ audit_storage_version }}/{{ audit_storage_artifact_name }}-{{ audit_storage_version }}.zip"
+audit_storage_zip_checksum: "sha1:{{ audit_storage_zip_url }}.sha1"
 
 audit_storage_download_artifact_name: alfresco-audit-storage-app
 

--- a/roles/audit_storage/molecule/default/converge.yml
+++ b/roles/audit_storage/molecule/default/converge.yml
@@ -8,5 +8,6 @@
         elasticsearch_major_version: '7.x'
     - role: audit_storage
       vars:
-        audit_storage_zip_url: "{{ acs_play_audit_storage_archive_url }}"
-        audit_storage_zip_checksum: "{{ acs_play_audit_storage_archive_checksum }}"
+        audit_storage_zip_url: >-
+          {{ acs_play_audit_storage_repository }}/{{ acs_play_audit_storage_artifact_name }}/{{ audit_storage_version }}/{{ acs_play_audit_storage_artifact_name }}-{{ audit_storage_version }}.zip
+        audit_storage_zip_checksum: "sha1:{{ audit_storage_zip_url }}.sha1"

--- a/roles/audit_storage/molecule/default/converge.yml
+++ b/roles/audit_storage/molecule/default/converge.yml
@@ -8,6 +8,4 @@
         elasticsearch_major_version: '7.x'
     - role: audit_storage
       vars:
-        audit_storage_zip_url: >-
-          {{ acs_play_audit_storage_repository }}/{{ acs_play_audit_storage_artifact_name }}/{{ audit_storage_version }}/{{ acs_play_audit_storage_artifact_name }}-{{ audit_storage_version }}.zip
-        audit_storage_zip_checksum: "sha1:{{ audit_storage_zip_url }}.sha1"
+        audit_storage_repository: "{{ acs_play_audit_storage_repository }}"

--- a/roles/audit_storage/molecule/default/converge.yml
+++ b/roles/audit_storage/molecule/default/converge.yml
@@ -7,3 +7,6 @@
       vars:
         elasticsearch_major_version: '7.x'
     - role: audit_storage
+      vars:
+        audit_storage_zip_url: "{{ acs_play_audit_storage_archive_url }}"
+        audit_storage_zip_checksum: "{{ acs_play_audit_storage_archive_checksum }}"

--- a/roles/audit_storage/molecule/default/molecule.yml
+++ b/roles/audit_storage/molecule/default/molecule.yml
@@ -27,5 +27,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/common/molecule/default/molecule.yml
+++ b/roles/common/molecule/default/molecule.yml
@@ -25,6 +25,7 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: testinfra
   env:

--- a/roles/elasticsearch/molecule/default/molecule.yml
+++ b/roles/elasticsearch/molecule/default/molecule.yml
@@ -22,5 +22,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/identity/molecule/default/molecule.yml
+++ b/roles/identity/molecule/default/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible
 

--- a/roles/java/molecule/default/molecule.yml
+++ b/roles/java/molecule/default/molecule.yml
@@ -23,3 +23,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/nginx/molecule/default/molecule.yml
+++ b/roles/nginx/molecule/default/molecule.yml
@@ -25,5 +25,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/postgres/molecule/default/molecule.yml
+++ b/roles/postgres/molecule/default/molecule.yml
@@ -30,3 +30,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/repository/molecule/default/converge.yml
+++ b/roles/repository/molecule/default/converge.yml
@@ -25,3 +25,5 @@
           - ../../configuration_files/alfresco-global.properties
         repository_nexus_username: "{{ lookup('env', 'NEXUS_USERNAME') }}"
         repository_nexus_password: "{{ lookup('env', 'NEXUS_PASSWORD') }}"
+        repository_acs_repository: "{{ acs_play_repository_acs_repository }}"
+        repository_api_explorer_repository: "{{ acs_play_repository_api_explorer_repository }}"

--- a/roles/repository/molecule/default/molecule.yml
+++ b/roles/repository/molecule/default/molecule.yml
@@ -37,3 +37,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/search/meta/argument_specs.yml
+++ b/roles/search/meta/argument_specs.yml
@@ -90,6 +90,11 @@ argument_specs:
           Insight Engine requires a specific entitlement.
         required: false
         default: alfresco-search-services
+      search_artifact_repository:
+        description: |
+          URL of the repository where the Search Service distribution is stored.
+        required: false
+        type: str
       search_zip_url:
         description: |
           The URL of the Search Service zip file to download.

--- a/roles/search/molecule/default/converge.yml
+++ b/roles/search/molecule/default/converge.yml
@@ -11,3 +11,4 @@
         {{ ansible_play_hosts_all | map('extract', hostvars, ['ansible_default_ipv4','address']) | first }}
       search_topology: replication
       search_shared_secret: alfresco with space
+      search_artifact_repository: "{{ acs_play_search_repository }}"

--- a/roles/search/molecule/default/molecule.yml
+++ b/roles/search/molecule/default/molecule.yml
@@ -36,3 +36,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/search_enterprise/molecule/default/converge.yml
+++ b/roles/search_enterprise/molecule/default/converge.yml
@@ -19,10 +19,16 @@
       vars:
         sfs_archive_username: "{{ molecule_nexus_username }}"
         sfs_archive_password: "{{ molecule_nexus_password }}"
+        sfs_repository: "{{ acs_play_sfs_repository }}"
 
     - name: "Include transformers"
       ansible.builtin.include_role:
         name: "transformers"
+      vars:
+        transformers_libreoffice_repository: "{{ acs_play_transformers_libreoffice_repository }}"
+        transformers_pdf_repository: "{{ acs_play_transformers_pdf_repository }}"
+        transformers_imagemagick_repository: "{{ acs_play_transformers_imagemagick_repository }}"
+        transformers_aio_repository: "{{ acs_play_transformers_aio_repository }}"
 
     - name: "Include t-router"
       ansible.builtin.include_role:
@@ -30,6 +36,7 @@
       vars:
         trouter_archive_username: "{{ molecule_nexus_username }}"
         trouter_archive_password: "{{ molecule_nexus_password }}"
+        trouter_repository: "{{ acs_play_trouter_repository }}"
 
     - name: "Include search_enterprise"
       ansible.builtin.include_role:
@@ -38,3 +45,4 @@
         elasticsearch_host: "{{ ansible_hostname }}"
         search_enterprise_zip_username: "{{ molecule_nexus_username }}"
         search_enterprise_zip_password: "{{ molecule_nexus_password }}"
+        search_enterprise_repository: "{{ acs_play_search_enterprise_repository }}"

--- a/roles/search_enterprise/molecule/default/molecule.yml
+++ b/roles/search_enterprise/molecule/default/molecule.yml
@@ -28,5 +28,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/sfs/molecule/default/converge.yml
+++ b/roles/sfs/molecule/default/converge.yml
@@ -13,3 +13,4 @@
             - $JAVA_OPTS
         sfs_archive_username: "{{ lookup('env', 'NEXUS_USERNAME') }}"
         sfs_archive_password: "{{ lookup('env', 'NEXUS_PASSWORD') }}"
+        sfs_repository: "{{ acs_play_sfs_repository }}"

--- a/roles/sfs/molecule/default/molecule.yml
+++ b/roles/sfs/molecule/default/molecule.yml
@@ -25,3 +25,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/sync/molecule/default/converge.yml
+++ b/roles/sync/molecule/default/converge.yml
@@ -6,7 +6,7 @@
     molecule_nexus_password: "{{ lookup('env', 'NEXUS_PASSWORD') }}"
     sync_amp_device_sync_version: 5.3.5
     sync_amp_device_sync_artifact_name: alfresco-device-sync-repo
-    sync_amp_device_sync_repository: https://artifacts.alfresco.com/nexus/content/groups/private/org/alfresco/services/sync
+    sync_amp_device_sync_repository: "{{ acs_play_repository_amp_device_sync_repository }}"
     sync_amp_device_sync_archive_url: "{{ sync_amp_device_sync_repository }}/{{ sync_amp_device_sync_artifact_name }}/{{ sync_amp_device_sync_version }}/{{ sync_amp_device_sync_artifact_name }}-{{ sync_amp_device_sync_version }}.amp"
   roles:
     - role: activemq

--- a/roles/sync/molecule/default/converge.yml
+++ b/roles/sync/molecule/default/converge.yml
@@ -40,6 +40,8 @@
         repository_properties: "{{ global_properties }}"
         repository_nexus_username: "{{ molecule_nexus_username }}"
         repository_nexus_password: "{{ molecule_nexus_password }}"
+        repository_acs_repository: "{{ acs_play_repository_acs_repository }}"
+        repository_api_explorer_repository: "{{ acs_play_repository_api_explorer_repository }}"
         repository_amp_downloads:
           - url: "{{ sync_amp_device_sync_archive_url }}"
             checksum: "sha1:{{ sync_amp_device_sync_archive_url }}.sha1"
@@ -52,6 +54,7 @@
       vars:
         sync_zip_username: "{{ molecule_nexus_username }}"
         sync_zip_password: "{{ molecule_nexus_password }}"
+        sync_zip_url: "{{ acs_play_sync_repository }}/{{ sync_artifact_name }}/{{ sync_version }}/{{ sync_artifact_name }}-{{ sync_version }}.zip"
         sync_environment:
           JAVA_OPTS:
             - -Xms512m

--- a/roles/sync/molecule/default/molecule.yml
+++ b/roles/sync/molecule/default/molecule.yml
@@ -30,5 +30,6 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars
 verifier:
   name: ansible

--- a/roles/tomcat/molecule/default/molecule.yml
+++ b/roles/tomcat/molecule/default/molecule.yml
@@ -23,3 +23,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/transformers/molecule/default/converge.yml
+++ b/roles/transformers/molecule/default/converge.yml
@@ -15,3 +15,7 @@
           JAVA_OPTS:
             - -Xms512m
             - -Xmx900m
+        transformers_libreoffice_repository: "{{ acs_play_transformers_libreoffice_repository }}"
+        transformers_pdf_repository: "{{ acs_play_transformers_pdf_repository }}"
+        transformers_imagemagick_repository: "{{ acs_play_transformers_imagemagick_repository }}"
+        transformers_aio_repository: "{{ acs_play_transformers_aio_repository }}"

--- a/roles/transformers/molecule/default/molecule.yml
+++ b/roles/transformers/molecule/default/molecule.yml
@@ -37,3 +37,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars

--- a/roles/trouter/molecule/default/converge.yml
+++ b/roles/trouter/molecule/default/converge.yml
@@ -10,6 +10,11 @@
     - name: "Include AIO"
       ansible.builtin.include_role:
         name: "transformers"
+      vars:
+        transformers_libreoffice_repository: "{{ acs_play_transformers_libreoffice_repository }}"
+        transformers_pdf_repository: "{{ acs_play_transformers_pdf_repository }}"
+        transformers_imagemagick_repository: "{{ acs_play_transformers_imagemagick_repository }}"
+        transformers_aio_repository: "{{ acs_play_transformers_aio_repository }}"
     - name: Flush Handlers
       ansible.builtin.meta: flush_handlers
     - name: "Include trouter"
@@ -22,3 +27,4 @@
             - -Xmx900m
         trouter_archive_username: "{{ lookup('env', 'NEXUS_USERNAME') }}"
         trouter_archive_password: "{{ lookup('env', 'NEXUS_PASSWORD') }}"
+        trouter_repository: "{{ acs_play_trouter_repository }}"

--- a/roles/trouter/molecule/default/molecule.yml
+++ b/roles/trouter/molecule/default/molecule.yml
@@ -37,3 +37,4 @@ provisioner:
   inventory:
     links:
       host_vars: host_vars
+      group_vars: ../../../../playbooks/group_vars


### PR DESCRIPTION
## Summary
Molecule scenarios only linked host_vars, so the repository URL variables defined in playbooks/group_vars weren't reachable from role tests, and some converge files hardcoded artifacts.alfresco.com directly. This links group_vars the same way in every role's molecule.yml, and every role that downloads an artifact now overrides its repository var with the corresponding acs_play_* variable (the same one playbooks/acs.yml passes in production), so changing artifacts_repositories in playbooks/group_vars/all.yml propagates to every molecule test without touching each role individually. Role defaults keep their artifacts.alfresco.com fallback for standalone role usage — only the test wiring changes.

## Test plan
- [ ] yamllint passes on all changed files
- [ ] Run molecule test for sync role and confirm it resolves the repository/zip URLs from playbooks/group_vars
- [ ] Run molecule test for adf_app role and confirm it resolves acc_repository/adw_repository
- [ ] Run molecule test for repository, search, search_enterprise, sfs, trouter and transformers roles and confirm they resolve their artifact repository from playbooks/group_vars
- [ ] Point artifacts_repositories.base_url at an alternate host and confirm the change propagates to all of the above without further edits

OPSEXP-4247