### PR TITLE
OPSEXP-4247 Bump alfresco.platform to 0.6.0 and align repository overrides

### DIFF
--- a/playbooks/acs.yml
+++ b/playbooks/acs.yml
@@ -574,7 +574,7 @@
       search_community_java_bin_path: "/opt/openjdk-{{ acs_play_java_core }}/bin/java"
       search_community_version: "{{ acs_play_search_community_version }}"
       search_community_artifact_name: "{{ acs_play_search_community_artifact_name }}"
-      search_community_repository: "{{ acs_play_search_community_repository }}"
+      search_community_repository_url: "{{ acs_play_search_community_repository }}"
       search_community_zip_url: "{{ acs_play_search_community_zip_url }}"
       search_community_zip_checksum: "{{ acs_play_search_community_zip_checksum }}"
       search_community_username: "{{ username }}"
@@ -833,6 +833,7 @@
     - role: alfresco.platform.cic_connector
       cic_connector_artifact_username: "{{ nexus_user }}"
       cic_connector_artifact_password: "{{ nexus_password }}"
+      cic_connector_artifact_repository_url: "{{ nexus_repository.enterprise_releases }}"
       cic_connector_java_home_path: "/opt/openjdk-{{ acs_play_java_core }}"
       cic_connector_artifact_default_version: "{{ acs_play_cic_connector_version }}"
       cic_connector_live_ingester_port: "{{ acs_play_cic_connector_live_ingester_port }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,7 @@ collections:
   - name: community.aws
     version: 11.1.0
   - name: alfresco.platform
-    version: 0.5.0
+    version: 0.6.0
   # Alternate source for alfresco.platform
   # - name: git+https://github.com/Alfresco/alfresco-ansible-collection.git
   #   type: git


### PR DESCRIPTION
## Summary
- Bumps requirements.yml's alfresco.platform pin from 0.5.0 to the newly released 0.6.0, replacing the temporary git-commit pin used on the test-archive branch to exercise that release ahead of time.
- Wires cic_connector_artifact_repository_url to nexus_repository.enterprise_releases so cic_connector resolves to the same deployment-configured repository as audit_storage and search_enterprise, instead of falling back to the collection role's own default host.
- Renames the search_community role override from search_community_repository to search_community_repository_url, following the role's own parameter rename in 0.6.0.

This carries over the non-experimental fixes from the test-archive branch, leaving out its nexus-archive host swap and credential-secret renames, which stay scoped to that branch.

OPSEXP-4247