### PR TITLE
OPSEXP-4389 Bump ImageMagick to 7.1.2-31-ci-1

### DIFF
--- a/roles/transformers/defaults/main.yml
+++ b/roles/transformers/defaults/main.yml
@@ -31,7 +31,7 @@ transformers_pdf_archive_name: "{{ transformers_pdf_artifact_name }}-{{ transfor
 transformers_pdf_archive_url: "{{ transformers_pdf_repository }}/{{ transformers_pdf_artifact_name }}/{{ transformers_pdf_version }}/{{ transformers_pdf_archive_name }}"
 transformers_pdf_archive_checksum: "sha1:{{ transformers_pdf_archive_url }}.sha1"
 
-transformers_imagemagick_version: 7.1.2-13-ci-1
+transformers_imagemagick_version: 7.1.2-31
 transformers_imagemagick_repository: https://artifacts.alfresco.com/nexus/content/groups/public/org/alfresco
 
 transformers_aio_artifact_name: alfresco-transform-core-aio

--- a/roles/transformers/defaults/main.yml
+++ b/roles/transformers/defaults/main.yml
@@ -31,7 +31,7 @@ transformers_pdf_archive_name: "{{ transformers_pdf_artifact_name }}-{{ transfor
 transformers_pdf_archive_url: "{{ transformers_pdf_repository }}/{{ transformers_pdf_artifact_name }}/{{ transformers_pdf_version }}/{{ transformers_pdf_archive_name }}"
 transformers_pdf_archive_checksum: "sha1:{{ transformers_pdf_archive_url }}.sha1"
 
-transformers_imagemagick_version: 7.1.2-31
+transformers_imagemagick_version: 7.1.2-31-ci-1
 transformers_imagemagick_repository: https://artifacts.alfresco.com/nexus/content/groups/public/org/alfresco
 
 transformers_aio_artifact_name: alfresco-transform-core-aio

--- a/vars/acs23.yml
+++ b/vars/acs23.yml
@@ -37,7 +37,7 @@ acs_play_tomcat_version: 10.1.59
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-31
+acs_play_transformers_imagemagick_version: 7.1.2-31-ci-1
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 15

--- a/vars/acs23.yml
+++ b/vars/acs23.yml
@@ -37,7 +37,7 @@ acs_play_tomcat_version: 10.1.59
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
+acs_play_transformers_imagemagick_version: 7.1.2-31
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 15

--- a/vars/acs25.yml
+++ b/vars/acs25.yml
@@ -38,7 +38,7 @@ acs_play_tomcat_version: 10.1.59
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
+acs_play_transformers_imagemagick_version: 7.1.2-31
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 16

--- a/vars/acs25.yml
+++ b/vars/acs25.yml
@@ -38,7 +38,7 @@ acs_play_tomcat_version: 10.1.59
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-31
+acs_play_transformers_imagemagick_version: 7.1.2-31-ci-1
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 16

--- a/vars/acs26.yml
+++ b/vars/acs26.yml
@@ -39,7 +39,7 @@ acs_play_tomcat_version: 11.0.25
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-13-ci-1
+acs_play_transformers_imagemagick_version: 7.1.2-31
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 17

--- a/vars/acs26.yml
+++ b/vars/acs26.yml
@@ -39,7 +39,7 @@ acs_play_tomcat_version: 11.0.25
 acs_play_trouter_version: 4.4.4
 acs_play_transformers_libreoffice_version: 7.2.5.1
 acs_play_transformers_pdf_version: 1.3.0-85
-acs_play_transformers_imagemagick_version: 7.1.2-31
+acs_play_transformers_imagemagick_version: 7.1.2-31-ci-1
 acs_play_transformers_aio_version: 5.4.4
 acs_play_jdbc_pg_driver_version: "{{ default_jdbc_pg_driver_version }}"
 acs_play_postgres_major_version: 17


### PR DESCRIPTION
OPSEXP-4389
## Summary

Updates the ImageMagick distribution from `7.1.2-13-ci-1` to `7.1.2-31-ci-1` for ACS 23, 25, and 26 deployments.

This build contains security fixes for high-severity CVEs affecting the previously deployed ImageMagick version.

## Release

Target release: `3.12.1`
